### PR TITLE
Improvements for pre-1.x

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Test service URLs — DO NOT COMMIT ACTUAL FILE
+# Copy this file to .env and fill in your real values.
+# This file is gitignored.
+
+API_DOCS=true
+CQF_RULER_R4="https://your-cqf-ruler-url/fhir/"
+DOCS_PREPEND_URL=""
+EXTERNAL_FHIR_SERVER_URL="https://your-external-fhir-server-url/"
+EXTERNAL_FHIR_SERVER_AUTH="your external fhir server auth"
+LOG_LEVEL="INFO"
+NLPAAS_URL="https://your-nlpaas-url.com"
+DEPLOY_URL="http://your-deploy-url"
+DB_CONNECTION_STRING="postgresql+psycopg://user:pass@your-postgres-url:port/dbname"
+DB_SCHEMA="your-db-schema"
+PRIMARYIDENTIFIER_SYSTEM="urn:oid:your-primary-identifier-system"
+PRIMARYIDENTIFIER_LABEL="your primary identifier label"
+KNOWLEDGEBASE_REPO_URL="https://user:token@your-git-url.com/your-knowledge-repo.git"

--- a/main.py
+++ b/main.py
@@ -73,8 +73,8 @@ app.add_middleware(
 # ================= Routers inclusion from src directory ===============
 app.include_router(main_router.router, tags=["Main API"])
 app.include_router(cql_router.router, tags=["CQL APIs"])
-app.include_router(forms_router.router, tags=["Forms APIs"])
 app.include_router(nlpql_router.router, tags=["NLPQL APIs"])
+app.include_router(forms_router.router, tags=["Forms APIs"])
 app.include_router(webhook.router, tags=["Webhook"])
 app.include_router(smartchartui.smartchart_router, tags=["SmartChart UI"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,22 @@
 [tool.ruff]
 line-length = 200
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+markers = [
+    "integration: end-to-end tests that require real external services (CQF Ruler, FHIR server). Run with: pytest -m integration",
+]
+
+[tool.pytest.ini_options.env]
+CQF_RULER_R4 = "http://localhost:8080/fhir"
+EXTERNAL_FHIR_SERVER_URL = "http://localhost:9090/fhir"
+EXTERNAL_FHIR_SERVER_AUTH = ""
+NLPAAS_URL = "False"
+LOG_LEVEL = "WARNING"
+API_DOCS = "false"
+KNOWLEDGEBASE_REPO_URL = ""
+DOCS_PREPEND_URL = ""
+DEPLOY_URL = "http://localhost/"
+DB_CONNECTION_STRING = "sqlite+pysqlite:///rcapi_test.sqlite"
+DB_SCHEMA = "rcapi"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+# Core dependencies
 fastapi==0.135.1
-fastapi-restful==0.6.0
+fastapi-utils==0.8.0
 fhir.resources==8.2.0
 gitpython==3.1.46
 httpx==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,12 @@ loguru==0.7.3
 pre-commit==4.5.1
 psycopg[binary,pool]==3.3.3
 pyjwt[crypto]==2.11.0
+
+# Test dependencies
+pytest>=8.0.0
+pytest-asyncio>=0.24.0
+pytest-env>=1.1.5
+pytest-mock>=3.14.0
 ruff==0.15.4
 SQLAlchemy==2.0.48
 typing-inspect==0.9.0

--- a/src/models/forms.py
+++ b/src/models/forms.py
@@ -50,7 +50,7 @@ def save_form_questionnaire(questionnaire_dict: dict):
         logger.info("Not completing POST operation because a Questionnaire with that name and version already exist on this FHIR Server")
         logger.info("Change Questionnaire name or version number or use PUT to update this version")
         return make_operation_outcome("duplicate", f"There is already a Questionnaire with this name with resource id {questionnaire_current_id}")
-    except KeyError:
+    except (KeyError, IndexError):
         logger.info("Questionnaire with that name not found, continuing POST operation")
 
     # Create Questionnaire in CQF Ruler
@@ -95,7 +95,7 @@ def get_form(form_name: str, form_version: str | None = None, return_Questionnai
         questionnaire = search_bundle["entry"][0]["resource"]
         logger.info(f"Found Questionnaire with name {form_name}, version {questionnaire['version']}, and form server ID {questionnaire['id']}")
         return questionnaire if not return_Questionnaire_class_obj else Questionnaire.parse_obj(questionnaire)
-    except KeyError:
+    except (KeyError, IndexError):
         logger.error(f"Questionnaire with name {form_name} and version {form_version} not found") if form_version else logger.error(f"Questionnaire with name {form_name} not found")
         return (
             make_operation_outcome("not-found", f"Questionnaire with name {form_name} and version {form_version} not found")

--- a/src/models/functions.py
+++ b/src/models/functions.py
@@ -4,7 +4,8 @@ import asyncio
 import base64
 import re
 import uuid
-from datetime import datetime
+from copy import deepcopy
+from datetime import datetime, timezone
 from typing import Literal, overload
 
 import httpx
@@ -329,16 +330,17 @@ def create_linked_results(results_in: list, form_name: str, patient_id: str):
                     tuple_flag = True
                     logger.info("Found Tuple in results")
                 if supporting_resources:
+                    answer_obs_focus_list = []
                     for resource in supporting_resources:
                         try:
-                            focus_object = {"reference": resource["fullUrl"]}
-                            answer_obs.focus.append(focus_object)  # type: ignore
+                            answer_obs_focus_list.append(Reference.model_construct(reference=resource["fullUrl"]))
                         except KeyError:
                             pass
+                    answer_obs.focus = answer_obs_focus_list
                 if empty_single_return and not supporting_resources:
                     continue
 
-                answer_obs = answer_obs.dict()
+                answer_obs = answer_obs.model_dump()
                 if isinstance(answer_obs["effectiveDateTime"], datetime):
                     answer_obs["effectiveDateTime"] = answer_obs["effectiveDateTime"].strftime("%Y-%m-%dT%H:%M:%SZ")
                 try:
@@ -733,7 +735,7 @@ def create_linked_results(results_in: list, form_name: str, patient_id: str):
                 for result in task_result:
                     if result.sentence and result.report_text and result.sentence.lower() not in re.sub(r"\n+", " ", result.report_text.lower()):
                         continue
-                    temp_answer_obs = answer_obs_template
+                    temp_answer_obs = answer_obs_template.model_copy(deep=True)
                     temp_answer_obs_uuid = str(uuid.uuid4())
                     temp_answer_obs.id = temp_answer_obs_uuid
                     temp_answer_obs.identifier[0].value = f"Observation/{temp_answer_obs_uuid}"  # type: ignore
@@ -744,30 +746,32 @@ def create_linked_results(results_in: list, form_name: str, patient_id: str):
                         continue
                     logger.debug(f"Found tuple in NLPQL results: {tuple_str}")
 
-                    tuple_dict = eval(f"{{{tuple_str}}}")
-                    # Commenting out below to try eval method
-                    # tuple_str_list = tuple_str.split('"')
-                    # if len(tuple_str_list) > 32:
-                    #     tuple_str_list[31] = "".join(tuple_str_list[31:])
-                    #     del tuple_str_list[32:]
-                    # for i in range(3, len(tuple_str_list), 8):
-                    #     key_name = tuple_str_list[i]
-                    #     value_name = tuple_str_list[i + 4]
-                    #     tuple_dict[key_name] = value_name
+                    try:
+                        tuple_dict = eval(f"{{{tuple_str}}}")
 
-                    tuple_result = NLPQLTupleResult(
-                        sourceNote=tuple_dict["sourceNote"],
-                        answerValue=(eval(tuple_dict["answerValue"]) if "{" in tuple_dict["answerValue"] else tuple_dict["answerValue"]),
-                        answerType=tuple_dict["answerType"],
-                    )
-                    tuple_result.sourceNote = tuple_result.sourceNote.strip()
+                        tuple_result = NLPQLTupleResult(
+                            sourceNote=tuple_dict["sourceNote"],
+                            answerValue=(eval(tuple_dict["answerValue"]) if "{" in tuple_dict["answerValue"] else tuple_dict["answerValue"]),
+                            answerType=tuple_dict["answerType"],
+                        )
+                        tuple_result.sourceNote = tuple_result.sourceNote.strip()
+                    except Exception as e:
+                        logger.exception(f"Exception during tuple eval: {e}")
+                        continue
 
-                    focus_ref: Reference = Reference.model_construct()
-                    focus_ref.reference = f"DocumentReference/{result.report_id}"
-                    temp_answer_obs.focus = [focus_ref]
+                    temp_answer_obs.focus = [Reference.model_construct(reference=f"DocumentReference/{result.report_id}")]
 
                     report_date = result.report_date if result.report_date else datetime.today().strftime("%Y-%m-%d")
-                    temp_answer_obs.effectiveDateTime = datetime.strptime(report_date, "%Y-%m-%d")
+                    if len(report_date) > 10:
+                        # Sometimes NLPaaS returns a full timestamp, handle up to seconds. Strip Z if present, or ignore it.
+                        clean_date = report_date.replace("Z", "")
+                        # Try parsing as ISO format or just fallback to string if it fails
+                        try:
+                            temp_answer_obs.effectiveDateTime = datetime.strptime(clean_date[:19], "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc)
+                        except ValueError:
+                            temp_answer_obs.effectiveDateTime = datetime.strptime(clean_date[:10], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+                    else:
+                        temp_answer_obs.effectiveDateTime = datetime.strptime(report_date[:10], "%Y-%m-%d").replace(tzinfo=timezone.utc)
 
                     if tuple_result.answerType:  # Check to make sure the answer value isnt an empty dictionary
                         temp_answer_obs.component = make_obs_component_for_nlp_result(tuple_result=tuple_result, result_type=tuple_result.answerType)
@@ -783,7 +787,7 @@ def create_linked_results(results_in: list, form_name: str, patient_id: str):
                             is_duplicate = True
 
                     if not is_duplicate:
-                        temp_answer_obs_dict = temp_answer_obs.dict()
+                        temp_answer_obs_dict = temp_answer_obs.model_dump()
                         if isinstance(temp_answer_obs_dict["effectiveDateTime"], datetime):
                             temp_answer_obs_dict["effectiveDateTime"] = temp_answer_obs_dict["effectiveDateTime"].strftime("%Y-%m-%dT%H:%M:%SZ")
                         tuple_observations.append(temp_answer_obs_dict)
@@ -815,7 +819,7 @@ def create_linked_results(results_in: list, form_name: str, patient_id: str):
                             f"failed with status code {supporting_resource_req.status_code}, continuing to create one for the Bundle"
                         )
 
-                        temp_doc_ref = dict(doc_ref_template)
+                        temp_doc_ref = deepcopy(doc_ref_template)
                         temp_doc_ref["id"] = result.report_id
                         temp_doc_ref["date"] = result.report_date if result.report_date else datetime.now().isoformat()
                         temp_doc_ref["identifier"] = [
@@ -1150,15 +1154,34 @@ async def start_jobs(post_body: StartJobsParameters) -> dict:
         parameters_post["parameter"][2]["resource"]["header"] = [f"Authorization: {external_fhir_server_auth}"]
 
     # Pass library id to be evaluated, gets back a future object that represent the pending status of the POST
-    futures = []
+    cql_task = None
+    nlpql_task = None
+
     if cql_flag:
         logger.info("Start submitting CQL jobs")
-        futures_cql = await run_cql(cql_library_server_ids, parameters_post)
-        futures.append(futures_cql)
-        logger.info("Submitted all CQL jobs")
+        cql_task = run_cql(cql_library_server_ids, parameters_post)
+
     if nlpql_flag and nlpaas_url != "False":
         logger.info("Start submitting NLPQL jobs")
-        futures_nlpql = await run_nlpql(nlpql_library_server_ids, patient_id, external_fhir_server_url, external_fhir_server_auth)
+        nlpql_task = run_nlpql(nlpql_library_server_ids, patient_id, external_fhir_server_url, external_fhir_server_auth)
+
+    tasks_to_await = []
+    if cql_task:
+        tasks_to_await.append(cql_task)
+    if nlpql_task:
+        tasks_to_await.append(nlpql_task)
+
+    results = await asyncio.gather(*tasks_to_await)
+
+    futures = []
+    result_idx = 0
+    if cql_task:
+        futures_cql = results[result_idx]
+        futures.append(futures_cql)
+        logger.info("Submitted all CQL jobs")
+        result_idx += 1
+    if nlpql_task:
+        futures_nlpql = results[result_idx]
         if isinstance(futures_nlpql, dict):
             return futures_nlpql
         futures.append(futures_nlpql)
@@ -1199,7 +1222,7 @@ async def start_jobs(post_body: StartJobsParameters) -> dict:
     else:
         logger.info(f"Finished linking results, returning Bundle with {bundled_results['total'] if 'total' in bundled_results else 0} entries")
 
-    # return Bundle(**bundled_results).dict(exclude_none=True)
+    # return Bundle(**bundled_results).model_dump(exclude_none=True)
     return bundled_results
 
 
@@ -1261,7 +1284,7 @@ def get_health_of_stack() -> dict:
         rcapi_reason = "RC-API is not up and running because: " + cqf_ruler_reason
         oo_template["issue"].append({"severity": "error", "code": "transient", "diagnostics": rcapi_reason})
 
-    return OperationOutcome.parse_obj(oo_template).dict()
+    return OperationOutcome.parse_obj(oo_template).model_dump()
 
 
 def get_param_index(parameter_list: list, param_name: str) -> int:

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -33,7 +33,7 @@ class ResultParameter(JobParameter):
     """Result Parameter for Job Status Support"""
 
     name: str = "result"
-    resource: dict = {"resourceType": "Bundle"}
+    resource: dict = {"resourceType": "Bundle", "type": "collection"}
 
 
 class JobStartParameter(JobParameter):

--- a/src/routers/forms_router.py
+++ b/src/routers/forms_router.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Body
 from fastapi.responses import JSONResponse
-from fastapi_restful.tasks import repeat_every
+from fastapi_utils.tasks import repeat_every
 from loguru import logger
 
 from src.models.forms import convert_jobpackage_csv_to_questionnaire, get_form, save_form_questionnaire
@@ -152,7 +152,7 @@ def update_form(form_name: str, new_questions: dict):
     try:
         resource_id = search_bundle["entry"][0]["resource"]["id"]
         logger.info(f"Found Questionnaire with name {form_name}")
-    except KeyError:
+    except (KeyError, IndexError):
         logger.error("Questionnaire with that name not found")
         return make_operation_outcome("not-found", f"Getting Questionnaire named {form_name} not found on server")
 

--- a/src/routers/smartchartui.py
+++ b/src/routers/smartchartui.py
@@ -111,7 +111,7 @@ def get_all_batch_jobs_request(include_patient: bool = False):
                 continue
             patient_resource = Patient(**read_patient(patient_id))
             batch_job_resource = update_patient_resource_in_parameters(batch_job_resource, patient_resource)
-            batch_jobs_as_resources.append(batch_job_resource.dict())
+            batch_jobs_as_resources.append(batch_job_resource.model_dump())
     else:
         batch_jobs_as_resources = requested_batch_jobs
     return [add_status_to_batch_job(batch_job) for batch_job in batch_jobs_as_resources]
@@ -129,7 +129,7 @@ def get_batch_job_request(id: str, include_patient: bool = False, response_class
             return {}
         patient_resource = Patient(**read_patient(patient_id))
         batch_job_resource = update_patient_resource_in_parameters(batch_job_resource, patient_resource)
-        requested_batch_job = batch_job_resource.dict()
+        requested_batch_job = batch_job_resource.model_dump()
     return requested_batch_job
 
 
@@ -152,7 +152,7 @@ def get_batch_job_results(id: str):
     # TODO: Per above, temp handling given an all statuses complete.
     # 1. Get child job IDs.
     child_job_list_resource: List = get_value_from_parameter(batch_job_resource, "childJobs", use_iteration_strategy=True, value_key="resource")
-    child_job_list_dict = child_job_list_resource.dict()
+    child_job_list_dict = child_job_list_resource.model_dump()
     child_job_list_dict_entries = child_job_list_dict["entry"]
     child_job_ids: list = [entry["item"]["display"] for entry in child_job_list_dict_entries]
 
@@ -248,7 +248,20 @@ def start_batch_job(post_body, background_tasks: BackgroundTasks, include_patien
     start_bodies = [temp_start_job_body(patient_id, form_name, job) for job in job_list]
 
     # Temporary holder for the list of responses to include in the batch job response
-    child_job_ids = [start_child_job_task(start_body=start_body, parent_batch_job_id=new_batch_job_batch_id, background_tasks=background_tasks) for start_body in start_bodies]
+    child_job_ids = []
+    child_jobs_to_run = []
+    for start_body in start_bodies:
+        new_job = ParametersJob()
+        uid_param_index = new_job.parameter.index([param for param in new_job.parameter if param.name == "jobId"][0])
+
+        new_uuid = uuid.uuid4()
+        new_job.parameter[uid_param_index].valueString = str(new_uuid)
+
+        job_id = str(new_job.parameter[uid_param_index].valueString)
+        child_job_ids.append(job_id)
+        child_jobs_to_run.append({"new_job": new_job, "job_id": job_id, "parent_batch_job_id": new_batch_job_batch_id, "start_body": start_body})
+
+    background_tasks.add_task(run_all_child_jobs_concurrently, child_jobs_to_run)
 
     list_resource = create_list_resource(child_job_ids)
     new_batch_job.parameter[child_jobs_param_index].resource = list_resource
@@ -271,10 +284,10 @@ def start_batch_job(post_body, background_tasks: BackgroundTasks, include_patien
         patient_id = get_value_from_parameter(batch_job_resource, "patientId", use_iteration_strategy=True, value_key="valueString")
         patient_resource = Patient(**read_patient(patient_id))
         batch_job_resource = update_patient_resource_in_parameters(batch_job_resource, patient_resource)
-        batch_job_resource = batch_job_resource.dict(exclude_none=True)
+        batch_job_resource = batch_job_resource.model_dump(exclude_none=True)
 
     if isinstance(batch_job_resource, Parameters):
-        batch_job_resource = batch_job_resource.dict(exclude_none=True)
+        batch_job_resource = batch_job_resource.model_dump(exclude_none=True)
 
     return PrettyJSONResponse(
         batch_job_resource,
@@ -282,17 +295,11 @@ def start_batch_job(post_body, background_tasks: BackgroundTasks, include_patien
     )
 
 
-def start_child_job_task(start_body: StartJobsParameters, parent_batch_job_id, background_tasks: BackgroundTasks):
-    new_job = ParametersJob()
-    uid_param_index = new_job.parameter.index([param for param in new_job.parameter if param.name == "jobId"][0])
+async def run_all_child_jobs_concurrently(child_jobs: list[dict]):
+    import asyncio
 
-    # TODO: Temporary fix to new_job creating duplicate UUIDs
-    new_uuid = uuid.uuid4()
-    new_job.parameter[uid_param_index].valueString = str(new_uuid)
-
-    job_id = str(new_job.parameter[uid_param_index].valueString)
-    background_tasks.add_task(run_child_job, new_job, job_id, parent_batch_job_id, start_body)
-    return job_id
+    tasks = [run_child_job(job["new_job"], job["job_id"], job["parent_batch_job_id"], job["start_body"]) for job in child_jobs]
+    await asyncio.gather(*tasks)
 
 
 async def run_child_job(new_job: ParametersJob, job_id: str, parent_batch_job_id: str, start_body: StartJobsParameters):

--- a/src/services/libraryhandler.py
+++ b/src/services/libraryhandler.py
@@ -44,7 +44,7 @@ def create_cql(cql):
         existing_cql_library = search_bundle["entry"][0]["resource"]
         logger.info(f"Found CQL Library with name {name} and version {version}, therefore will be updating the resource with PUT.")
         put_flag = True
-    except KeyError:
+    except (KeyError, IndexError):
         put_flag = False
         logger.info("CQL Library with that name not found, continuing POST operation")
 
@@ -56,8 +56,7 @@ def create_cql(cql):
 
     # Create Library object
     data = {"name": name, "version": version, "status": "draft", "experimental": True, "type": {"coding": [{"code": "logic-library"}]}, "content": [{"contentType": "text/cql", "data": base64_cql}]}
-    cql_library = Library(**data)
-    cql_library = cql_library.dict()
+    cql_library = Library(**data).model_dump()
     cql_library["content"][0]["data"] = base64_cql
     logger.info("Created Library object")
 
@@ -106,7 +105,7 @@ def create_nlpql(nlpql):
         existing_nlpql_library = search_bundle["entry"][0]["resource"]
         put_flag = True
         logger.info(f"Found NLPQL Library with name {name} and version {version}, therefore will be updating this library with PUT.")
-    except KeyError:
+    except (KeyError, IndexError):
         put_flag = False
         logger.info("NLPQL Library with that name not found, continuing POST operation")
 
@@ -125,8 +124,7 @@ def create_nlpql(nlpql):
         "type": {"coding": [{"code": "logic-library"}]},
         "content": [{"contentType": "text/nlpql", "data": base64_nlpql}],
     }
-    nlpql_library = Library(**data)
-    nlpql_library = nlpql_library.dict()
+    nlpql_library = Library(**data).model_dump()
     nlpql_library["content"][0]["data"] = base64_nlpql
 
     if not put_flag:
@@ -167,7 +165,7 @@ def get_library(library_name: str, library_type: Literal["cql", "nlpql"]) -> str
     try:
         library = search_bundle["entry"][0]["resource"]
         logger.info(f"Found {library_type.upper()} Library with name {library_name}")
-    except KeyError:
+    except (KeyError, IndexError):
         logger.error(f"{library_type.upper()} Library with that name not found")
         return make_operation_outcome("not-found", f"{library_type.upper()} Library named {library_name} not found on the FHIR server.")
 

--- a/src/util/fhirclient.py
+++ b/src/util/fhirclient.py
@@ -37,6 +37,9 @@ class FhirClient:
     def readResource(self, resource_type: str, id: str) -> httpx.Response:
         return self.__http_request__(method="GET", url_path=f"{resource_type}/{id}")
 
+    def deleteResource(self, resource_type: str, id: str) -> httpx.Response:
+        return self.__http_request__(method="DELETE", url_path=f"{resource_type}/{id}")
+
     @typing.overload
     def searchResource(self, resource_type: str, parameters: dict | None = None, flatten: typing.Literal[False] = False) -> dict:
         pass

--- a/src/util/settings.py
+++ b/src/util/settings.py
@@ -42,8 +42,10 @@ if external_fhir_server_url[-1] != "/":
 if deploy_url[-1] != "/":
     deploy_url += "/"
 
-if nlpaas_url[-1] != "/":
+if nlpaas_url and nlpaas_url.lower() != "false" and nlpaas_url[-1] != "/":
     nlpaas_url += "/"
+elif nlpaas_url.lower() == "false":
+    nlpaas_url = ""
 
 transport: httpx.HTTPTransport = httpx.HTTPTransport(retries=5)
 httpx_client: httpx.Client = httpx.Client(transport=transport)

--- a/tests/Testing_Walkthrough.md
+++ b/tests/Testing_Walkthrough.md
@@ -1,0 +1,291 @@
+# RC-API Test Suite Walkthrough
+
+## Overview
+
+The test suite lives entirely under `tests/`. It is structured as **7 test files** (one per router/topic), a shared **`conftest.py`**, a **`fixtures/`** folder of JSON data, and a **`test_integration.py`** file that hits real external services.
+
+```
+tests/
+├── conftest.py                     # Shared fixtures & helpers
+├── fixtures/
+│   ├── fhir_bundle_empty.json
+│   ├── fhir_integration_questionnaire.json
+│   ├── fhir_library_cql.json
+│   ├── fhir_library_nlpql.json
+│   ├── fhir_patient.json
+│   ├── fhir_questionnaire.json
+│   └── user_data.json
+├── test_main_router.py
+├── test_webhook.py
+├── test_cql_router.py
+├── test_nlpql_router.py
+├── test_forms_router.py
+├── test_smartchartui_router.py
+└── test_integration.py             # marked @integration — requires real services
+```
+
+---
+
+## `conftest.py` — Shared Infrastructure
+
+Everything in this file is available to all test files automatically.
+
+### Environment Bootstrap (lines 18–32)
+Sets all required env vars **before any `src.*` import**. This is critical because `src/util/settings.py` reads `os.environ` at module scope (not lazily). The defaults point to localhost and use a SQLite test DB so no real services are required.
+
+### `app` fixture (session-scoped)
+Imports the FastAPI app with three things patched so the lifespan startup doesn't run real I/O:
+- `startup_connect` — no DB connection attempted
+- `clone_repo_to_temp_folder` — no git clone
+- `init_jobs_array` — no CQF Ruler library preload
+
+### `client` fixture (session-scoped)
+A `TestClient` wrapping the app. Session-scoped means it's created once and shared across the entire test run. `raise_server_exceptions=False` means 500 errors come back as responses rather than pytest exceptions.
+
+### `mock_httpx` fixture (function-scoped)
+Patches `src.util.settings.httpx_client` and re-exports it to every module that imported it at module scope (9 total targets). Tests that need to control outbound HTTP use this — setting `.get.return_value`, `.post.return_value`, etc.
+
+### `mock_fhir_clients` fixture (function-scoped)
+Patches `external_fhir_client` and `internal_fhir_client` in `smartchartui.py` with `MagicMock`s. Tests destructure the return value as `ext_client, internal_client = mock_fhir_clients`.
+
+### `mock_jobstate` fixture (function-scoped)
+Patches all 8 jobstate functions in `smartchartui.py` (e.g., `get_job`, `add_to_batch_jobs`, `delete_batch_job`) with individual `MagicMock`s. Returns a dict keyed by function name so tests can configure each independently.
+
+### `make_response` / `make_fhir_searchset` helpers
+- `make_response(status, json_body, text)` — builds a real `httpx.Response` (not a mock) for use as `mock_httpx.xxx.return_value`.
+- `make_fhir_searchset(resources)` — wraps a list of FHIR resources into a FHIR Bundle searchset.
+
+---
+
+## `tests/fixtures/`
+
+| File | Purpose |
+|---|---|
+| `fhir_bundle_empty.json` | A FHIR Bundle with `total: 0` and no entries — used to simulate "not found" from CQF Ruler |
+| `fhir_library_cql.json` | A minimal FHIR `Library` resource with base64-encoded CQL content |
+| `fhir_library_nlpql.json` | Same structure for an NLPQL library |
+| `fhir_patient.json` | A minimal FHIR `Patient` resource |
+| `fhir_questionnaire.json` | A minimal FHIR `Questionnaire` with name `TestQuestionnaire` and a few items |
+| `fhir_integration_questionnaire.json` | The full `SETNETInfantFollowUpIntegrationTesting` Questionnaire — uploaded to CQF Ruler before integration tests run |
+| `user_data.json` | User-provided real patient IDs, job inputs, and expected outputs for data-driven + integration tests |
+
+### `user_data.json` structure
+```json
+{
+  "patients":              [...],   // for TestPatientSearchUserData parametrize
+  "start_jobs_requests":   [...],   // for TestStartJobsUserData + integration start_jobs tests
+  "batch_jobs_requests":   [...],   // for TestBatchJobUserData + integration batch poll test
+  "jobpackage_csv_samples": [...]   // currently unused by tests
+}
+```
+Fields containing `"REPLACE_ME"` cause tests to auto-skip (`pytest.skip`).
+
+---
+
+## `test_main_router.py` — Health & Config Endpoints
+
+Covers `GET /`, `GET /health`, `GET /config`.
+
+| Class | What it tests |
+|---|---|
+| `TestRootEndpoint` | `/` returns a FHIR `OperationOutcome` with `code: processing` and a "base URL" diagnostic message |
+| `TestHealthEndpoint` | `/health` with a monkeypatched `get_health_of_stack` — checks 200 and response shape |
+| `TestConfigEndpoint` | `/config` returns `{}` when not configured, or a `ConfigEndpointModel` with `primaryIdentifier` when patched |
+
+---
+
+## `test_webhook.py` — GitHub Webhook
+
+Covers `POST /webhook`.
+
+| Test | What it asserts |
+|---|---|
+| `test_webhook_returns_acknowledged` | Returns `"Acknowledged"` string on success |
+| `test_webhook_calls_clone_with_ssh_url` | `clone_repo_to_temp_folder` is called exactly once with the `ssh_url` |
+| `test_webhook_uses_ssh_not_clone_url` | SSH URL not HTTPS clone URL is passed |
+| `test_webhook_missing_repository_key_raises` | Malformed payload (no `repository` key) → 500 |
+
+---
+
+## `test_cql_router.py` — CQL Library CRUD
+
+Covers `GET /forms/cql`, `GET /forms/cql/{name}`, `POST /forms/cql`, `PUT /forms/cql/{name}`.
+
+### `TestGetCqlLibraries`
+- Mocks CQF Ruler returning a searchset Bundle → verifies 200 + `resourceType: Bundle`
+- CQF Ruler returning 500 → 200 with `OperationOutcome` (code: `transient`)
+- Empty bundle → `total: 0`
+
+### `TestGetCqlByName`
+- Library found → response is the base64-decoded plain-text CQL
+- Not found (empty bundle) → `OperationOutcome not-found`
+- Server error → `OperationOutcome transient`
+
+### `TestSaveCql`
+A real CQL string `VALID_CQL = "library TestLibrary version '1.0.0'..."` is used as the POST body.
+- New library → POST to CQF Ruler → 201 `OperationOutcome` with the new ID in diagnostics
+- Existing library → GET finds it, triggers PUT instead → still 201
+- CQL validation fails → 500 `OperationOutcome`
+- Empty body → 400 (custom FastAPI exception handler converts 422 → 400)
+- CQF Ruler POST fails → 500
+
+### `TestUpdateCql`
+- Successful PUT → 201 `OperationOutcome` with `severity: information`
+- Empty body → 400
+
+---
+
+## `test_nlpql_router.py` — NLPQL Library CRUD
+
+Covers `GET /forms/nlpql`, `GET /forms/nlpql/{name}`, `POST /forms/nlpql`, `PUT /forms/nlpql/{name}`.
+
+Structurally mirrors `test_cql_router.py` but with NLPQL-specific concerns.
+
+> **Route Ordering**: The file documents that `nlpql_router` must be registered **before** `forms_router` in `main.py`, otherwise `GET /forms/nlpql` is incorrectly captured by the forms router.
+
+> **NLPAAS_URL quirk**: `settings.py` appends `/` to `NLPAAS_URL`, so the value `"False"` becomes `"False/"` (truthy). Tests that want to simulate "no NLPaaS" directly patch `src.services.libraryhandler.nlpaas_url` to `""` instead of relying on the env var.
+
+| Class | Key scenarios |
+|---|---|
+| `TestGetNlpqlLibraries` | Bundle returned, empty bundle, 503 → OperationOutcome |
+| `TestGetNlpqlByName` | Found → plain-text NLPQL, not found → OO not-found, 503 → OO transient |
+| `TestSaveNlpql` | No NLPaaS → 400, success → 201, empty body → 400, existing lib → PUT, validation fails → 400 |
+| `TestUpdateNlpql` | Success → 201, empty body → 400 |
+
+---
+
+## `test_forms_router.py` — Questionnaire & Job Orchestration
+
+Covers `GET /forms`, `GET /forms/{name}`, `POST /forms`, `PUT /forms/{name}`, `POST /forms/start`, `GET /forms/status/all`, `GET /forms/status/{uid}`, `POST /forms/jobPackageToQuestionnaire`.
+
+### `TestGetForms` / `TestGetFormByName`
+- Standard CQF Ruler mocking pattern: success → Bundle, 503 → OperationOutcome
+- `GET /forms/{name}` — found → `Questionnaire` resource; empty bundle → `OperationOutcome not-found`
+
+### `TestSaveForm` / `TestUpdateForm`
+- **Save**: GET (check exists) → empty bundle → POST to CQF Ruler → 201 → returns informational `OperationOutcome`
+- **Update**: GET finds existing → PUT → 200 informational OO; empty bundle → OO (known production edge case noted in comment); CQF Ruler GET fails → `transient` OO
+
+### `TestStartJobs`
+| Test | Scenario |
+|---|---|
+| `test_start_jobs_sync_calls_start_jobs` | Sync path — patches `start_jobs` and checks the Bundle is returned |
+| `test_start_jobs_async_creates_job_entry` | `?asyncFlag=true` path — returns `Parameters` with `jobId` and a `Location` header |
+| `test_start_jobs_missing_required_fields` | Incomplete body → 400 or 422 |
+
+### `TestJobStatus`
+- `GET /forms/status/all` with empty `jobs` dict → `{}`
+- `GET /forms/status/{uid}` not found → 404 OO with `code: code-invalid`
+- `GET /forms/status/{uid}` found → 200 `Parameters` resource
+
+### `TestJobPackageToQuestionnaire`
+- Invalid CSV → error OO (via monkeypatched converter)
+- Valid CSV → Questionnaire resource returned
+
+### `TestStartJobsUserData` _(data-driven)_
+Parametrized over `start_jobs_requests` from `user_data.json`. Mocks `start_jobs` to return the `expected_output` and asserts the resourceType matches. Auto-skips if `REPLACE_ME` is present.
+
+---
+
+## `test_smartchartui_router.py` — SmartChart UI Endpoints
+
+The largest unit test file. Covers all 10 `smartchartui.py` endpoints.
+
+### Helper functions
+- `_make_job_dict(job_id, status)` — builds a ParametersJob dict as stored in DB
+- `_make_batch_job_dict(batch_id, child_ids)` — builds a BatchParametersJob dict with a child job List resource
+
+### `TestReadPatient` / `TestSearchPatient`
+- `readResource` called with patient ID → response is the patient fixture JSON.
+- Search variants tested: no params (all), `?_id=`, `?name=`, `?identifier=`, `?name=&birthdate=` — each asserts the correct parameters dict was forwarded to `ext_client.searchResource`.
+
+### `TestSearchGroup`
+- Group with one member reference → list includes `Group` + resolved `Patient`
+- Empty group list → `[]`
+
+### `TestSearchQuestionnaire`
+- Returns list of Questionnaires from `internal_fhir_client`
+- Empty → `[]`
+
+### `TestGetJob`
+- `get_job` returns `None` → 404 OO not-found
+- `get_job` returns job dict → 200 `Parameters`
+
+### `TestGetAllBatchJobs`
+- Empty DB → `[]`
+- One batch job with one child → response includes `batchJobStatus` parameter (computed from child statuses)
+
+### `TestGetBatchJobById`
+- Not found → 404 OO
+- Found → 200 `Parameters`
+
+### `TestDeleteBatchJob`
+- Success → 200 OO with "deleted" code
+- Not found → 404 (mock returns a 404 JSONResponse)
+
+### `TestPostBatchJob`
+- `get_form` returns a Questionnaire, `add_to_batch_jobs` returns `True` → 200 `Parameters` with `batchId` + `Location` header
+- `add_to_batch_jobs` returns `False` → 500 OO
+
+### `TestGetBatchJobResults`
+- No batch job in DB → 404
+- Batch job with one complete child job → 200 Bundle (status observation assembled from child results)
+
+### Data-driven classes
+- `TestBatchJobUserData` — parametrized POST /smartchartui/batchjob from `user_data.json`
+- `TestPatientSearchUserData` — parametrized GET /smartchartui/Patient/{id} from `user_data.json`
+
+---
+
+## `test_integration.py` — End-to-End Integration Tests
+
+> Requires a `.env` file at the repo root with real service URLs. Marked `@pytest.mark.integration` — only runs with `-m integration`.
+
+### The `integration_client` fixture
+This is the centerpiece of the file. It:
+1. Reads URLs from `.env` (`CQF_RULER_R4`, `EXTERNAL_FHIR_SERVER_URL`, `NLPAAS_URL`, `DB_CONNECTION_STRING`)
+2. **Setup**: POSTs `fhir_integration_questionnaire.json` to CQF Ruler (using raw `httpx`) → captures the server-assigned ID
+3. Patches all module-level URL variables so every outbound call from the app hits the real servers
+4. Patches DB engine if a real `DB_CONNECTION_STRING` is provided
+5. `yield c` — all tests run here using the live-patched `TestClient`
+6. **Teardown** (while `c` and patches are still active): DELETEs the Questionnaire from CQF Ruler, then iterates `_batch_ids_to_cleanup` and calls `DELETE /smartchartui/batchjob/{id}` through `c` directly
+
+> The teardown runs **inside** `with TestClient(app) as c:` — this is intentional. An earlier version tried creating a second `TestClient` in teardown, which re-triggered the lifespan/`startup_connect` and crashed with a DB schema error.
+
+### Helper functions
+- `_load_env_file(path)` — parses a `.env` file without python-dotenv dependency
+- `_assert_not_error_operation_outcome(body, context)` — fails with a descriptive message if the response is an error OO
+- `_extract_batch_id(response_body)` — finds `parameter[name=="batchId"].valueString`
+- `_get_status_observation(results_body)` — finds `Observation/status-observation` in a results Bundle
+
+### `TestStartJobsFullForm` (`scenarios[0]`)
+- `POST /forms/start` with the first entry from `user_data.json`
+- Asserts 200, `resourceType: Bundle`, and at least 1 entry
+- Logs resource type breakdown
+
+### `TestStartJobsSingleJob` (finds scenario with `job` param)
+- Same endpoint, but picks a scenario that has a specific `job` parameter (single CQL library run)
+- Same shape assertions
+
+### `TestBatchJobPolling`
+Full async batch job lifecycle:
+1. `POST /smartchartui/batchjob` with `jobPackage: SETNETInfantFollowUpIntegrationTesting`
+2. Extracts `batchId`, appends it to `_batch_ids_to_cleanup`
+3. Polls `GET /smartchartui/results/{batchId}` every 15s for up to 5 minutes
+4. On each poll, checks for `Observation/status-observation` with `status == "complete"`
+5. Final assertion: at least 10 entries in the completed bundle
+
+---
+
+## Running the Tests
+
+```bash
+# All unit tests (no real services needed)
+conda run -n rcapi python -m pytest tests/ -v
+
+# Integration tests only (requires .env)
+conda run -n rcapi python -m pytest tests/test_integration.py -v -s -m integration
+
+# Single class
+conda run -n rcapi python -m pytest tests/test_smartchartui_router.py::TestPostBatchJob -v
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,186 @@
+"""
+conftest.py — Shared fixtures for all RC-API tests.
+
+IMPORTANT: Environment variables MUST be set before ANY import from src.*
+because src/util/settings.py reads os.environ at module level (not lazily).
+We do this at the top of this file before any src imports.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+#     Set ALL required env vars HERE, before any src.* import happens.
+#     settings.py calls os.environ["CQF_RULER_R4"] at module scope.
+# ---------------------------------------------------------------------------
+_TEST_ENV = {
+    "CQF_RULER_R4": "http://localhost:8080/fhir/",
+    "EXTERNAL_FHIR_SERVER_URL": "http://localhost:9090/fhir/",
+    "EXTERNAL_FHIR_SERVER_AUTH": "",
+    "NLPAAS_URL": "False",  # string "False" → settings.py appends "/" → "False/" (truthy)
+    "LOG_LEVEL": "WARNING",  # tests that test "no NLPaaS" patch libraryhandler.nlpaas_url directly
+    "API_DOCS": "false",
+    "KNOWLEDGEBASE_REPO_URL": "",
+    "DOCS_PREPEND_URL": "",
+    "DEPLOY_URL": "http://localhost/",
+    "DB_CONNECTION_STRING": "sqlite+pysqlite:///rcapi_test.sqlite",
+    "DB_SCHEMA": "rcapi",
+}
+for _key, _val in _TEST_ENV.items():
+    os.environ.setdefault(_key, str(_val))
+
+
+# ---------------------------------------------------------------------------
+# Now it is safe to import from src / fastapi / httpx
+# ---------------------------------------------------------------------------
+import httpx  # noqa: E402
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Helper: load a JSON fixture by filename stem
+# ---------------------------------------------------------------------------
+def load_fixture(name: str) -> dict:
+    """Load a JSON fixture file from tests/fixtures/<name>.json"""
+    path = FIXTURES_DIR / f"{name}.json"
+    with open(path) as f:
+        return json.load(f)
+
+
+def load_user_data() -> dict:
+    """Load the user-supplied test data fixture."""
+    return load_fixture("user_data")
+
+
+# ---------------------------------------------------------------------------
+# App fixture — patches lifespan so no DB/repo startup runs
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def app():
+    """Return the FastAPI app with lifespan bypassed for testing."""
+    with (
+        patch("src.util.databaseclient.startup_connect"),
+        patch("src.util.git.clone_repo_to_temp_folder"),
+        patch("src.routers.forms_router.init_jobs_array"),
+    ):
+        from main import app as _app
+
+        yield _app
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    """Session-scoped sync TestClient — reused across all tests."""
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# httpx mock — replaces the global httpx_client used across all routers
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def mock_httpx(monkeypatch):
+    """
+    Patches `src.util.settings.httpx_client` with a MagicMock and propagates
+    it to every module that imports it at the top level.
+
+    Usage in tests:
+        def test_foo(client, mock_httpx):
+            mock_httpx.get.return_value = make_response(200, {...})
+    """
+    mock = MagicMock(spec=httpx.Client)
+    targets = [
+        "src.util.settings.httpx_client",
+        "src.routers.cql_router.httpx_client",
+        "src.routers.nlpql_router.httpx_client",
+        "src.routers.forms_router.httpx_client",
+        "src.routers.smartchartui.httpx_client",
+        "src.services.libraryhandler.httpx_client",
+        "src.models.functions.httpx_client",
+        "src.models.forms.httpx_client",  # get_form / save_form_questionnaire
+        "src.util.fhirclient.client",  # FhirClient internals
+    ]
+    for t in targets:
+        monkeypatch.setattr(t, mock)
+    yield mock
+
+
+# ---------------------------------------------------------------------------
+# FhirClient mock — patches the two FhirClient instances in smartchartui
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def mock_fhir_clients(monkeypatch):
+    """
+    Patches `external_fhir_client` and `internal_fhir_client` in
+    smartchartui.py with MagicMocks.
+    Returns (external_mock, internal_mock).
+    """
+    ext = MagicMock()
+    internal = MagicMock()
+    monkeypatch.setattr("src.routers.smartchartui.external_fhir_client", ext)
+    monkeypatch.setattr("src.routers.smartchartui.internal_fhir_client", internal)
+    return ext, internal
+
+
+# ---------------------------------------------------------------------------
+# DB-related mocks — patch jobstate functions that hit SQLite
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def mock_jobstate(monkeypatch):
+    """
+    Patches all jobstate functions used by smartchartui so tests don't need a
+    real database.
+    """
+    mocks = {}
+    for fn in [
+        "get_job",
+        "get_all_batch_jobs",
+        "get_batch_job",
+        "delete_batch_job",
+        "add_to_batch_jobs",
+        "add_to_jobs",
+        "update_job_to_complete",
+        "get_child_job_statuses",
+    ]:
+        m = MagicMock()
+        monkeypatch.setattr(f"src.routers.smartchartui.{fn}", m)
+        mocks[fn] = m
+    return mocks
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build mock httpx.Response objects
+# ---------------------------------------------------------------------------
+def make_response(status_code: int, json_body: dict | None = None, text: str | None = None) -> httpx.Response:
+    """
+    Build a real httpx.Response (not a mock) with the given status code and body.
+    Use json_body for JSON responses or `text` for plain-text (CQL/NLPQL).
+    """
+    if json_body is not None:
+        content = json.dumps(json_body).encode()
+        headers = {"content-type": "application/json"}
+    elif text is not None:
+        content = text.encode()
+        headers = {"content-type": "text/plain"}
+    else:
+        content = b""
+        headers = {}
+    return httpx.Response(status_code=status_code, content=content, headers=headers)
+
+
+def make_fhir_searchset(resources: list[dict]) -> dict:
+    """Wrap a list of FHIR resources into a minimal searchset Bundle."""
+    return {
+        "resourceType": "Bundle",
+        "type": "searchset",
+        "total": len(resources),
+        "entry": [{"resource": r} for r in resources],
+    }

--- a/tests/fixtures/fhir_bundle_empty.json
+++ b/tests/fixtures/fhir_bundle_empty.json
@@ -1,0 +1,7 @@
+{
+    "resourceType": "Bundle",
+    "id": "test-searchset-empty",
+    "type": "searchset",
+    "entry": [],
+    "total": 0
+}

--- a/tests/fixtures/fhir_integration_questionnaire.json
+++ b/tests/fixtures/fhir_integration_questionnaire.json
@@ -1,0 +1,3905 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://gtri.gatech.edu/fakeFormIg/StructureDefinition/smartchart-form"
+        ]
+    },
+    "extension": [
+        {
+            "url": "http://gtri.gatech.edu/fakeFormIg/cql-form-job-list",
+            "extension": [
+                {
+                    "url": "form-job",
+                    "valueString": "ifu_information.cql"
+                },
+                {
+                    "url": "form-job",
+                    "valueString": "ifu_physical_exam_findings.cql"
+                },
+                {
+                    "url": "form-job",
+                    "valueString": "ifu_covid_19_module.cql"
+                }
+            ]
+        },
+        {
+            "url": "http://gtri.gatech.edu/fakeFormIg/nlpql-form-job-list",
+            "extension": [
+                {
+                    "url": "form-job",
+                    "valueString": "ifu_information.nlpql"
+                },
+                {
+                    "url": "form-job",
+                    "valueString": "ifu_physical_exam_findings.nlpql"
+                },
+                {
+                    "url": "form-job",
+                    "valueString": "ifu_covid_19_module.nlpql"
+                }
+            ]
+        }
+    ],
+    "url": "http://gtri.gatech.edu/fakeFormIg/Questionnaire/SETNETInfantFollowUp",
+    "version": "0.2.0",
+    "name": "SETNETInfantFollowUpIntegrationTesting",
+    "title": "SETNET - Infant Follow Up (Minimal for RC-API Integration Testing)",
+    "status": "draft",
+    "experimental": true,
+    "subjectType": [
+        "Patient"
+    ],
+    "publisher": "GTRI",
+    "description": "Form used to support the SET-NET Data Dictionary elements",
+    "useContext": [
+        {
+            "code": {
+                "system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+                "code": "workflow",
+                "display": "Workflow Setting"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "http://gtri.gatech.edu/fakeFormIg/CodeSystem/custom",
+                        "code": "smartchartui",
+                        "display": "SmartChart UI"
+                    }
+                ]
+            }
+        }
+    ],
+    "item": [
+        {
+            "linkId": "Information",
+            "text": "Information",
+            "type": "group",
+            "item": [
+                {
+                    "linkId": "1",
+                    "text": "CDC Infant ID (e.g.,AZS123456B; LAC1000000C, LAC1000000D)",
+                    "type": "string"
+                },
+                {
+                    "linkId": "2",
+                    "text": "Infant medical record abstraction done",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "3",
+                    "text": "Infant no longer being monitored (i.e., lost to follow-up)",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "4",
+                    "text": "If yes, what is the primary reason for no longer monitoring?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Moved out of area of surveillance"
+                        },
+                        {
+                            "valueString": "Laboratory results not found"
+                        },
+                        {
+                            "valueString": "Not selected for MRA"
+                        },
+                        {
+                            "valueString": "Unable to acquire medical records"
+                        },
+                        {
+                            "valueString": "No consent/public health authority"
+                        },
+                        {
+                            "valueString": "Other"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "5",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_information.ig_death"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_information.ig_death"
+                        }
+                    ],
+                    "linkId": "7",
+                    "text": "Is the infant/child deceased?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_information.ig_death_dt"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_information.ig_death_dt"
+                        }
+                    ],
+                    "linkId": "8",
+                    "text": "If yes, date of infant/child death:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_information.ig_death_dx"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_information.ig_death_dx"
+                        }
+                    ],
+                    "linkId": "9",
+                    "text": "If yes, cause(s) of infant/child death:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_information.ig_visit_dt"
+                        }
+                    ],
+                    "linkId": "10",
+                    "text": "Date of visit:",
+                    "type": "date"
+                },
+                {
+                    "linkId": "11",
+                    "text": "Calculated age at visit (months):",
+                    "type": "integer"
+                }
+            ]
+        },
+        {
+            "linkId": "Physical Exam Findings",
+            "text": "Physical Exam Findings",
+            "type": "group",
+            "item": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_yn"
+                        }
+                    ],
+                    "linkId": "12",
+                    "text": "Were physical exam findings reported?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "13",
+                    "text": "If yes for above, provide findings of physical exam for each system. If findings not reported for a specific system, select \"Not reported\".",
+                    "type": "display"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_general"
+                        }
+                    ],
+                    "linkId": "14",
+                    "text": "General",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_general_sp"
+                        }
+                    ],
+                    "linkId": "15",
+                    "text": "If abnormal, describe:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_heent"
+                        }
+                    ],
+                    "linkId": "16",
+                    "text": "Head, eyes, ears, nose, throat (HEENT)",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_heent_sp"
+                        }
+                    ],
+                    "linkId": "17",
+                    "text": "If abnormal, describe:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_cardio"
+                        }
+                    ],
+                    "linkId": "18",
+                    "text": "Cardiovascular",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_cardio_sp"
+                        }
+                    ],
+                    "linkId": "19",
+                    "text": "If abnormal, describe:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_lung"
+                        }
+                    ],
+                    "linkId": "20",
+                    "text": "Pulmonary/lung/respiratory",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_lung_sp"
+                        }
+                    ],
+                    "linkId": "21",
+                    "text": "If abnormal, describe:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_abd"
+                        }
+                    ],
+                    "linkId": "22",
+                    "text": "Abdominal/gastrointestinal",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_abd_sp"
+                        }
+                    ],
+                    "linkId": "23",
+                    "text": "If abnormal, describe:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_gu"
+                        }
+                    ],
+                    "linkId": "24",
+                    "text": "Genitourinary",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_gu_sp"
+                        }
+                    ],
+                    "linkId": "25",
+                    "text": "If abnormal, describe:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_muske"
+                        }
+                    ],
+                    "linkId": "26",
+                    "text": "Musculoskeletal",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_muske_sp"
+                        }
+                    ],
+                    "linkId": "27",
+                    "text": "If abnormal, describe:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_neuro"
+                        }
+                    ],
+                    "linkId": "28",
+                    "text": "Neurologic",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_neuro_sp"
+                        }
+                    ],
+                    "linkId": "29",
+                    "text": "If abnormal, describe:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_skin"
+                        }
+                    ],
+                    "linkId": "30",
+                    "text": "Skin/Integument",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_exm_skin_sp"
+                        }
+                    ],
+                    "linkId": "31",
+                    "text": "If abnormal, describe:",
+                    "type": "string"
+                },
+                {
+                    "linkId": "32",
+                    "text": "Describe any additional abnormal findings not included in the previous questions.",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_lt"
+                        }
+                    ],
+                    "linkId": "33",
+                    "text": "Infant/child length (cm):",
+                    "type": "quantity"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_wt"
+                        }
+                    ],
+                    "linkId": "34",
+                    "text": "Infant/child weight (kg):",
+                    "type": "quantity"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_hc"
+                        }
+                    ],
+                    "linkId": "35",
+                    "text": "Infant/child head circumference (cm):",
+                    "type": "quantity"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_physical_exam_findings.ig_bstfed"
+                        }
+                    ],
+                    "linkId": "36",
+                    "text": "Is the infant receiving breastmilk?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "linkId": "Referrals",
+            "text": "Referrals",
+            "type": "group",
+            "item": [
+                {
+                    "linkId": "37",
+                    "text": "Was the child referred to any of the following?",
+                    "type": "display"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "38",
+                    "text": "Early Intervention",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "39",
+                    "text": "Physical Therapy (PT)",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "40",
+                    "text": "Occupational Therapy (OT)",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "41",
+                    "text": "Speech Language Pathology (SLP)",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "42",
+                    "text": "Ophthalmology",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "43",
+                    "text": "Audiology",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "44",
+                    "text": "Developmental specialist",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "45",
+                    "text": "Medical or surgical specialist",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "46",
+                    "text": "Other",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "47",
+                    "text": "If medical or surgical specialist, specify:",
+                    "type": "string"
+                },
+                {
+                    "linkId": "48",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "linkId": "49",
+                    "text": "ICD-10 diagnosis codes associated with this visit:",
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "linkId": "Opthalmology Evaluation",
+            "text": "Opthalmology Evaluation",
+            "type": "group",
+            "item": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "50",
+                    "text": "Was an ophthalmology evaluation performed?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "51",
+                    "text": "Date of ophthalmology evaluation:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "52",
+                    "text": "Results of ophthalmology evaluation:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal findings"
+                        },
+                        {
+                            "valueString": "Abnormal findings"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "53",
+                    "text": "If abnormal findings, describe:",
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "linkId": "Audiology Evaluation",
+            "text": "Audiology Evaluation",
+            "type": "group",
+            "item": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "54",
+                    "text": "Was an audiology evaluation performed?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "55",
+                    "text": "Date of audiology evaluation:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "56",
+                    "text": "Results of audiology evaluation:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal"
+                        },
+                        {
+                            "valueString": "Abnormal unilateral"
+                        },
+                        {
+                            "valueString": "Abnormal bilateral"
+                        },
+                        {
+                            "valueString": "Abnormal, laterality not specified"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "57",
+                    "text": "If abnormal, select findings:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Conductive hearing loss (CHL)"
+                        },
+                        {
+                            "valueString": "Sensorineural hearing loss (SNHL)"
+                        },
+                        {
+                            "valueString": "Mixed hearing loss"
+                        },
+                        {
+                            "valueString": "Auditory neuropathy spectrum disorder (ANSD)"
+                        },
+                        {
+                            "valueString": "Hearing loss, type unknown/not specified"
+                        },
+                        {
+                            "valueString": "Other"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "58",
+                    "text": "If other, describe:",
+                    "type": "string"
+                },
+                {
+                    "linkId": "59",
+                    "text": "Abstractor notes",
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "linkId": "COVID-19 Module",
+            "text": "COVID-19 Module",
+            "type": "group",
+            "item": [
+                {
+                    "linkId": "60",
+                    "text": "Infant Follow-up Form: COVID-19 Module",
+                    "type": "display"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_covid_19_module.iv_visitnb"
+                        }
+                    ],
+                    "linkId": "61",
+                    "text": "How was the newborn visit conducted?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "In-person visit"
+                        },
+                        {
+                            "valueString": "Telehealth visit"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_covid_19_module.iv_jaundice"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_covid_19_module.iv_jaundice"
+                        }
+                    ],
+                    "linkId": "62",
+                    "text": "Did the infant have jaundice requiring phototherapy after birth hospitalization?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_covid_19_module.iv_hosp"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/nlpqlTask",
+                            "valueString": "ifu_covid_19_module.iv_hosp"
+                        }
+                    ],
+                    "linkId": "63",
+                    "text": "Was the infant hospitalized after birth hospitalization?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_covid_19_module.iv_hosp_adm_dt"
+                        }
+                    ],
+                    "linkId": "64",
+                    "text": "If yes, date of admission:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "ifu_covid_19_module.iv_hosp_why"
+                        }
+                    ],
+                    "linkId": "65",
+                    "text": "If yes, admission diagnosis codes:",
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "linkId": "Hepatitis C Module",
+            "text": "Hepatitis C Module",
+            "type": "group",
+            "item": [
+                {
+                    "linkId": "66",
+                    "text": "Infant Follow-up Form: Hepatitis C Module",
+                    "type": "display"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "67",
+                    "text": "Was the infant/child diagnosed with liver disease?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "68",
+                    "text": "If yes, which kind:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "69",
+                    "text": "If yes, date of diagnosis:",
+                    "type": "date"
+                }
+            ]
+        },
+        {
+            "linkId": "Developmental Screening",
+            "text": "Developmental Screening",
+            "type": "group",
+            "item": [
+                {
+                    "linkId": "70",
+                    "text": "## First Developmental Screening or Assessment",
+                    "type": "display"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "71",
+                    "text": "Name of first standardized developmental screen or assessment performed:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Ages & Stages Questionnaire 3rd ed (ASQ-3)"
+                        },
+                        {
+                            "valueString": "Ages & Questions Questionnaires: Social-Emotional 2nd ed (ASQ:SE-2)"
+                        },
+                        {
+                            "valueString": "Parents' Evaluation of Developmental Status (PEDS)"
+                        },
+                        {
+                            "valueString": "Denver Developmental Screening Test (DDST)"
+                        },
+                        {
+                            "valueString": "Bayley Scales of Infant and Toddler Development (BSID-III)"
+                        },
+                        {
+                            "valueString": "Modified Checklist for Autism in Toddlers (M-CHAT)"
+                        },
+                        {
+                            "valueString": "Other"
+                        },
+                        {
+                            "valueString": "None reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "72",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "73",
+                    "text": "Date of screening or assessment 1:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "74",
+                    "text": "Communication or language 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "75",
+                    "text": "Gross motor 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "76",
+                    "text": "Fine motor 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "77",
+                    "text": "Cognitive or problem solving 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "78",
+                    "text": "Social-emotional 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "79",
+                    "text": "Adaptive 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "80",
+                    "text": "Autism 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Low Risk"
+                        },
+                        {
+                            "valueString": "Medium Risk"
+                        },
+                        {
+                            "valueString": "High Risk"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "81",
+                    "text": "Overall score 1 (if reported)",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "82",
+                    "text": "Describe all additional findings related to development 1",
+                    "type": "string"
+                },
+                {
+                    "linkId": "83",
+                    "text": "## Second Developmental Screening or Assessment",
+                    "type": "display"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "84",
+                    "text": "Name of second standardized developmental screen or assessment performed:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Ages & Stages Questionnaire 3rd ed (ASQ-3)"
+                        },
+                        {
+                            "valueString": "Ages & Questions Questionnaires: Social-Emotional 2nd ed (ASQ:SE-2)"
+                        },
+                        {
+                            "valueString": "Parents' Evaluation of Developmental Status (PEDS)"
+                        },
+                        {
+                            "valueString": "Denver Developmental Screening Test (DDST)"
+                        },
+                        {
+                            "valueString": "Bayley Scales of Infant and Toddler Development (BSID-III)"
+                        },
+                        {
+                            "valueString": "Modified Checklist for Autism in Toddlers (M-CHAT)"
+                        },
+                        {
+                            "valueString": "Other"
+                        },
+                        {
+                            "valueString": "None reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "85",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "86",
+                    "text": "Date of screening or assessment 2.",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "87",
+                    "text": "Communication or language 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "88",
+                    "text": "Gross motor 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "89",
+                    "text": "Fine motor 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "90",
+                    "text": "Cognitive or problem solving 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "91",
+                    "text": "Social-emotional 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "92",
+                    "text": "Adaptive 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "93",
+                    "text": "Autism 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Low Risk"
+                        },
+                        {
+                            "valueString": "Medium Risk"
+                        },
+                        {
+                            "valueString": "High Risk"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "94",
+                    "text": "Overall score 2 (if reported)",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "95",
+                    "text": "Describe all additional findings related to development 2",
+                    "type": "string"
+                },
+                {
+                    "linkId": "96",
+                    "text": "## Third Developmental Screening or Assessment",
+                    "type": "display"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "97",
+                    "text": "Name of third standardized developmental screen or assessment performed:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Ages & Stages Questionnaire 3rd ed (ASQ-3)"
+                        },
+                        {
+                            "valueString": "Ages & Questions Questionnaires: Social-Emotional 2nd ed (ASQ:SE-2)"
+                        },
+                        {
+                            "valueString": "Parents' Evaluation of Developmental Status (PEDS)"
+                        },
+                        {
+                            "valueString": "Denver Developmental Screening Test (DDST)"
+                        },
+                        {
+                            "valueString": "Bayley Scales of Infant and Toddler Development (BSID-III)"
+                        },
+                        {
+                            "valueString": "Modified Checklist for Autism in Toddlers (M-CHAT)"
+                        },
+                        {
+                            "valueString": "Other"
+                        },
+                        {
+                            "valueString": "None reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "98",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "99",
+                    "text": "Date of developmental screening or assessment 3:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "100",
+                    "text": "Communication or language 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "101",
+                    "text": "Gross motor 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "102",
+                    "text": "Fine motor 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "103",
+                    "text": "Cognitive or problem solving 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "104",
+                    "text": "Social-emotional 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "105",
+                    "text": "Adaptive 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "106",
+                    "text": "Autism 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Low Risk"
+                        },
+                        {
+                            "valueString": "Medium Risk"
+                        },
+                        {
+                            "valueString": "High Risk"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "107",
+                    "text": "Overall score 3 (if reported)",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "108",
+                    "text": "Describe all additional findings related to development 3",
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "linkId": "Imaging",
+            "text": "Imaging",
+            "type": "group",
+            "item": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "109",
+                    "text": "Did the infant/child have an MRI of the brain and/or spine?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "110",
+                    "text": "If yes, date of MRI of the brain and/or spine:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "111",
+                    "text": "If yes, verbatim findings of MRI of the brain and/or spine:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "112",
+                    "text": "Did the infant/child have a CT of the brain, head, neck, and/or spine?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "113",
+                    "text": "If yes, date of CT of the brain, head, neck, and/or spine:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "114",
+                    "text": "If yes, verbatim findings of the CT of the brain, head, neck, and/or spine:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "115",
+                    "text": "Did the infant/child have an ultrasound (U/S) of the head?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "116",
+                    "text": "If yes, date of the U/S of the head:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "117",
+                    "text": "If yes, verbatim findings of the U/S of the head:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "118",
+                    "text": "Did the infant/child have a U/S of the spine?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "119",
+                    "text": "If yes, date of the U/S of the spine:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "120",
+                    "text": "If yes, verbatim findings of the U/S of the spine:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "121",
+                    "text": "Did the infant/child have an x-ray of the skull, neck and/or back?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "122",
+                    "text": "If yes, date of the x-ray of the skull, neck and/or back:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "123",
+                    "text": "If yes, verbatim findings of the x-ray of the skull, neck and/or back:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "124",
+                    "text": "Did the infant/child have long bone x-rays?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes, changes consistent with CS"
+                        },
+                        {
+                            "valueString": "Yes, no signs of CS"
+                        },
+                        {
+                            "valueString": "Yes, unknown if signs of CS"
+                        },
+                        {
+                            "valueString": "No x-rays"
+                        },
+                        {
+                            "valueString": "Unknown"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "125",
+                    "text": "If yes, date of the long bone x-rays:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "126",
+                    "text": "If yes, verbatim findings of the long bone x-rays:",
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "linkId": "Syphilis Treatment",
+            "text": "Syphilis Treatment",
+            "type": "group",
+            "item": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "127",
+                    "text": "Did the infant/child receive treatment for syphilis? (1st)",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes, with aqueous or procaine penicillin for 10 days"
+                        },
+                        {
+                            "valueString": "Yes, with benzathine penicillin x 1"
+                        },
+                        {
+                            "valueString": "Yes, with other treatment"
+                        },
+                        {
+                            "valueString": "No treatment"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "128",
+                    "text": "If yes, start date of treatment: (1st)",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "129",
+                    "text": "Did the infant/child receive treatment for syphilis? (2nd)",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes, with aqueous or procaine penicillin for 10 days"
+                        },
+                        {
+                            "valueString": "Yes, with benzathine penicillin x 1"
+                        },
+                        {
+                            "valueString": "Yes, with other treatment"
+                        },
+                        {
+                            "valueString": "No treatment"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "130",
+                    "text": "If yes, start date of treatment: (2nd)",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "131",
+                    "text": "Did the infant/child receive treatment for syphilis? (3rd)",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes, with aqueous or procaine penicillin for 10 days"
+                        },
+                        {
+                            "valueString": "Yes, with benzathine penicillin x 1"
+                        },
+                        {
+                            "valueString": "Yes, with other treatment"
+                        },
+                        {
+                            "valueString": "No treatment"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "132",
+                    "text": "If yes, start date of treatment: (3rd)",
+                    "type": "date"
+                }
+            ]
+        },
+        {
+            "linkId": "Syphilis Complications",
+            "text": "Syphilis Complications",
+            "type": "group",
+            "item": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "133",
+                    "text": "Was the infant/child diagnosed with leptomeningitis?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "134",
+                    "text": "If yes, date of diagnosis:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "135",
+                    "text": "Was the infant/child diagnosed with chronic meningovascular syphilis?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "136",
+                    "text": "If yes, date of diagnosis:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "137",
+                    "text": "Was the infant/child diagnosed with nephrotic syndrome?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "138",
+                    "text": "If yes, date of diagnosis:",
+                    "type": "date"
+                }
+            ]
+        },
+        {
+            "linkId": "Cytomegalovirus Module",
+            "text": "Cytomegalovirus Module",
+            "type": "group",
+            "item": [
+                {
+                    "linkId": "140",
+                    "text": "Case classification",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Confirmed cCMV disease"
+                        },
+                        {
+                            "valueString": "Confirmed cCMV infection"
+                        },
+                        {
+                            "valueString": "Probable cCMV disease"
+                        },
+                        {
+                            "valueString": "Not a case"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "142",
+                    "text": "Name of first standardized developmental screen or assessment performed:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "ASQ3, Ages & Stages Questionnaire 3rd ed (ASQ-3)"
+                        },
+                        {
+                            "valueString": "ASQSE, Ages & Questions Questionnaires: Social-Emotional 2nd ed (ASQ:SE-2)"
+                        },
+                        {
+                            "valueString": "PEDS, Parents' Evaluation of Developmental Status (PEDS)"
+                        },
+                        {
+                            "valueString": "DDST, Denver Developmental Screening Test (DDST)"
+                        },
+                        {
+                            "valueString": "BAYLEY, Bayley Scales of Infant and Toddler Development (BSID-III)"
+                        },
+                        {
+                            "valueString": "MCHAT, Modified Checklist for Autism in Toddlers (M-CHAT)"
+                        },
+                        {
+                            "valueString": "OTH, Other"
+                        },
+                        {
+                            "valueString": "NAH, None reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "143",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "144",
+                    "text": "Date of screening or assessment 1:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "145",
+                    "text": "Communication or language 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "146",
+                    "text": "Gross motor 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "147",
+                    "text": "Fine motor 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "148",
+                    "text": "Cognitive or problem solving 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "149",
+                    "text": "Social-emotional 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "150",
+                    "text": "Adaptive 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "151",
+                    "text": "Autism 1",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Low Risk"
+                        },
+                        {
+                            "valueString": "Medium Risk"
+                        },
+                        {
+                            "valueString": "High Risk"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "152",
+                    "text": "Overall score 1 (if reported)",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "153",
+                    "text": "Describe all additional findings related to development 1",
+                    "type": "string"
+                },
+                {
+                    "linkId": "154",
+                    "text": "## Second Developmental Screening or Assessment",
+                    "type": "display"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "155",
+                    "text": "Name of second standardized developmental screen or assessment performed:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "ASQ3, Ages & Stages Questionnaire 3rd ed (ASQ-3)"
+                        },
+                        {
+                            "valueString": "ASQSE, Ages & Questions Questionnaires: Social-Emotional 2nd ed (ASQ:SE-2)"
+                        },
+                        {
+                            "valueString": "PEDS, Parents' Evaluation of Developmental Status (PEDS)"
+                        },
+                        {
+                            "valueString": "DDST, Denver Developmental Screening Test (DDST)"
+                        },
+                        {
+                            "valueString": "BAYLEY, Bayley Scales of Infant and Toddler Development (BSID-III)"
+                        },
+                        {
+                            "valueString": "MCHAT, Modified Checklist for Autism in Toddlers (M-CHAT)"
+                        },
+                        {
+                            "valueString": "OTH, Other"
+                        },
+                        {
+                            "valueString": "NAH, None reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "156",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "157",
+                    "text": "Date of screening or assessment 2.",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "158",
+                    "text": "Communication or language 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "159",
+                    "text": "Gross motor 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "160",
+                    "text": "Fine motor 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "161",
+                    "text": "Cognitive or problem solving 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "162",
+                    "text": "Social-emotional 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "163",
+                    "text": "Adaptive 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "164",
+                    "text": "Autism 2",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Low Risk"
+                        },
+                        {
+                            "valueString": "Medium Risk"
+                        },
+                        {
+                            "valueString": "High Risk"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "165",
+                    "text": "Overall score 2 (if reported)",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "166",
+                    "text": "Describe all additional findings related to development 2",
+                    "type": "string"
+                },
+                {
+                    "linkId": "167",
+                    "text": "## Third Developmental Screening or Assessment",
+                    "type": "display"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "168",
+                    "text": "Name of third standardized developmental screen or assessment performed:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "ASQ3, Ages & Stages Questionnaire 3rd ed (ASQ-3)"
+                        },
+                        {
+                            "valueString": "ASQSE, Ages & Questions Questionnaires: Social-Emotional 2nd ed (ASQ:SE-2)"
+                        },
+                        {
+                            "valueString": "PEDS, Parents' Evaluation of Developmental Status (PEDS)"
+                        },
+                        {
+                            "valueString": "DDST, Denver Developmental Screening Test (DDST)"
+                        },
+                        {
+                            "valueString": "BAYLEY, Bayley Scales of Infant and Toddler Development (BSID-III)"
+                        },
+                        {
+                            "valueString": "MCHAT, Modified Checklist for Autism in Toddlers (M-CHAT)"
+                        },
+                        {
+                            "valueString": "OTH, Other"
+                        },
+                        {
+                            "valueString": "NAH, None reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "169",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "170",
+                    "text": "Date of developmental screening or assessment 3:",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "171",
+                    "text": "Communication or language 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "172",
+                    "text": "Gross motor 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "173",
+                    "text": "Fine motor 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "174",
+                    "text": "Cognitive or problem solving 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "175",
+                    "text": "Social-emotional 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "176",
+                    "text": "Adaptive 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Normal/Passed"
+                        },
+                        {
+                            "valueString": "Monitoring"
+                        },
+                        {
+                            "valueString": "Abnormal/Failed/Needs further evaluation"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "177",
+                    "text": "Autism 3",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Low Risk"
+                        },
+                        {
+                            "valueString": "Medium Risk"
+                        },
+                        {
+                            "valueString": "High Risk"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "178",
+                    "text": "Overall score 3 (if reported)",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "179",
+                    "text": "Describe all additional findings related to development 3",
+                    "type": "string"
+                },
+                {
+                    "linkId": "180",
+                    "text": "Was an amplification or other Assisted Listening Device (ALD) recommended for the infant?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "181",
+                    "text": "Did the infant receive an amplification or other Assistant Listening Device (ALD)?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "182",
+                    "text": "If yes AND received, type of ALD:",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Bone Anchored Hearing Aid (BAHA)"
+                        },
+                        {
+                            "valueString": "Cochlear Implant"
+                        },
+                        {
+                            "valueString": "FM System"
+                        },
+                        {
+                            "valueString": "Hearing Aid"
+                        },
+                        {
+                            "valueString": "Other"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "183",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "184",
+                    "text": "Was the infant diagnosed with cerebral palsy?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "185",
+                    "text": "If yes, Gross Motor Function Classification score",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Level I"
+                        },
+                        {
+                            "valueString": "Level II"
+                        },
+                        {
+                            "valueString": "Level III"
+                        },
+                        {
+                            "valueString": "Level IV"
+                        },
+                        {
+                            "valueString": "Level V"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "186",
+                    "text": "What type of CP was the infant diagnosed with?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Spastic quadriplegia"
+                        },
+                        {
+                            "valueString": "Spastic diplegia"
+                        },
+                        {
+                            "valueString": "Spastic hemiplegia"
+                        },
+                        {
+                            "valueString": "Athetoid/ Dyskinetic"
+                        },
+                        {
+                            "valueString": "Ataxic"
+                        },
+                        {
+                            "valueString": "Other"
+                        },
+                        {
+                            "valueString": "Unspecified type"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "187",
+                    "text": "If other, specify:",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "188",
+                    "text": "Was the infant diagnosed with having seizures?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "189",
+                    "text": "Did the infant have an MRI of the brain and/or spine?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "190",
+                    "text": "If yes, date of MRI of the brain and/or spine",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "191",
+                    "text": "If yes, verbatim findings of MRI of the brain and/or spine",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "192",
+                    "text": "Did the infant have a CT of the brain, head, neck, and/or spine? ",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "193",
+                    "text": "If yes, date of CT of the brain, head, neck, and/or spine",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "194",
+                    "text": "If yes, verbatim findings of the CT of the brain, head, neck, and/or spine",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "195",
+                    "text": "Did the infant have an ultrasound (U/S) of the head?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "196",
+                    "text": "If yes, date of the U/S of the head",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "197",
+                    "text": "If yes, verbatim findings of the U/S of the head",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "198",
+                    "text": "Did the infant receive treatment for cCMV?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "199",
+                    "text": "Indications for anti-viral treatment",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "200",
+                    "text": "Ganciclovir",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "201",
+                    "text": "If yes, start date of Ganciclovir treatment",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "202",
+                    "text": "If yes, end date of Ganciclovir treatment",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "203",
+                    "text": "Valganciclovir",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "204",
+                    "text": "If yes, start date of Valganciclovir treatment",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "205",
+                    "text": "If yes, end date of Valganciclovir treatment",
+                    "type": "date"
+                },
+                {
+                    "linkId": "206",
+                    "text": "Other treatment for cCMV",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "207",
+                    "text": "If yes, specify:",
+                    "type": "string"
+                },
+                {
+                    "linkId": "208",
+                    "text": "If yes, other treatment start date",
+                    "type": "date"
+                },
+                {
+                    "linkId": "209",
+                    "text": "If yes, other treatment end date",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "210",
+                    "text": "If the infant was treated for cCMV, was complete blood count performed after treatment started?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueString": "Yes"
+                        },
+                        {
+                            "valueString": "No"
+                        },
+                        {
+                            "valueString": "Not reported"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "211",
+                    "text": "If yes, what were the lowest levels of absolute neutrophil count (cells/mm3)?",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "212",
+                    "text": "Date of lowest absolute neutrophil count",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "213",
+                    "text": "If yes, what were the lowest hemoglobin level (g/DL)?",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "214",
+                    "text": "Date of the lowest hemoglobin level",
+                    "type": "date"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "215",
+                    "text": "If yes, what were the lowest platelet count (cells/mm3)?",
+                    "type": "string"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ],
+                    "linkId": "216",
+                    "text": "Date of the lowest platelet count",
+                    "type": "date"
+                },
+                {
+                    "linkId": "217",
+                    "text": "Reason for treatment termination",
+                    "type": "string"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/fhir_library_cql.json
+++ b/tests/fixtures/fhir_library_cql.json
@@ -1,0 +1,21 @@
+{
+    "resourceType": "Library",
+    "id": "test-cql-library-001",
+    "name": "TestLibrary",
+    "version": "1.0.0",
+    "status": "draft",
+    "experimental": true,
+    "type": {
+        "coding": [
+            {
+                "code": "logic-library"
+            }
+        ]
+    },
+    "content": [
+        {
+            "contentType": "text/cql",
+            "data": "bGlicmFyeSBUZXN0TGlicmFyeSB2ZXJzaW9uICcxLjAuMCcKdXNpbmcgRkhJUiB2ZXJzaW9uICc0LjAuMScKY29udGV4dCBQYXRpZW50CmRlZmluZSAiUGF0aWVudE5hbWUiOiBQYXRpZW50Lm5hbWU="
+        }
+    ]
+}

--- a/tests/fixtures/fhir_library_nlpql.json
+++ b/tests/fixtures/fhir_library_nlpql.json
@@ -1,0 +1,21 @@
+{
+    "resourceType": "Library",
+    "id": "test-nlpql-library-001",
+    "name": "TestNLPQLLibrary",
+    "version": "1.0.0",
+    "status": "draft",
+    "experimental": true,
+    "type": {
+        "coding": [
+            {
+                "code": "logic-library"
+            }
+        ]
+    },
+    "content": [
+        {
+            "contentType": "text/nlpql",
+            "data": "Ly8gUGhlbm90eXBlIGxpYnJhcnkgVGVzdE5MUFFMTGlicmFyeQpwaGVub3R5cGUgIlRlc3ROTFBRTExpYnJhcnkiIHZlcnNpb24gIjEuMC4wIjsKZG9jdW1lbnRzZXQgbXlEb2NzOiBDbGFyaXR5LmNyZWF0ZVJlcG9ydFRhZ0xpc3QoWyJSYWRpb2xvZ3kiXSk7"
+        }
+    ]
+}

--- a/tests/fixtures/fhir_patient.json
+++ b/tests/fixtures/fhir_patient.json
@@ -1,0 +1,25 @@
+{
+    "resourceType": "Patient",
+    "id": "test-patient-001",
+    "meta": {
+        "versionId": "1",
+        "lastUpdated": "2024-01-01T00:00:00Z"
+    },
+    "identifier": [
+        {
+            "system": "http://hospital.example.org",
+            "value": "MRN-001"
+        }
+    ],
+    "name": [
+        {
+            "use": "official",
+            "family": "Doe",
+            "given": [
+                "John"
+            ]
+        }
+    ],
+    "gender": "male",
+    "birthDate": "1990-01-15"
+}

--- a/tests/fixtures/fhir_questionnaire.json
+++ b/tests/fixtures/fhir_questionnaire.json
@@ -1,0 +1,62 @@
+{
+    "resourceType": "Questionnaire",
+    "id": "test-questionnaire-001",
+    "name": "TestQuestionnaire",
+    "title": "Test Questionnaire",
+    "status": "active",
+    "version": "1.0.0",
+    "useContext": [
+        {
+            "code": {
+                "system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+                "code": "focus"
+            },
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "code": "smartchartui"
+                    }
+                ]
+            }
+        }
+    ],
+    "extension": [
+        {
+            "url": "http://gtri.gatech.edu/fakeFormIg/cql-form-job-list",
+            "extension": [
+                {
+                    "url": "form-job",
+                    "valueString": "TestLibrary.cql"
+                }
+            ]
+        },
+        {
+            "url": "http://gtri.gatech.edu/fakeFormIg/nlpql-form-job-list",
+            "extension": []
+        }
+    ],
+    "item": [
+        {
+            "linkId": "group-1",
+            "text": "Demographics",
+            "type": "group",
+            "item": [
+                {
+                    "linkId": "1.1",
+                    "text": "Patient Name",
+                    "type": "string",
+                    "extension": [
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cqlTask",
+                            "valueString": "TestLibrary.PatientName"
+                        },
+                        {
+                            "url": "http://gtri.gatech.edu/fakeFormIg/cardinality",
+                            "valueString": "single"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/user_data.json
+++ b/tests/fixtures/user_data.json
@@ -1,0 +1,359 @@
+{
+    "_comment_integration": "See .env.integration.example — copy it to .env.integration (gitignored) and fill in your real service URLs before running: pytest tests/test_integration.py -m integration",
+    "patients": [
+        {
+            "id": "625747",
+            "name": [
+                {
+                    "use": "official",
+                    "text": "Baby McBaby",
+                    "family": "McBaby",
+                    "given": [
+                        "Baby"
+                    ]
+                }
+            ],
+            "birthDate": "2150-01-01",
+            "identifier": [
+                {
+                    "use": "usual",
+                    "type": {
+                        "text": "GA8"
+                    },
+                    "system": "urn:oid:1.2.840.114350.1.13.876.1.4.8.725198.0",
+                    "value": "999888777"
+                }
+            ],
+            "expected_resource_type": "Patient"
+        }
+    ],
+    "questionnaires": [
+        {
+            "name": "SETNETInfantFollowUp",
+            "expected_resource_type": "Questionnaire"
+        }
+    ],
+    "cql_libraries": [
+        {
+            "name": "ifu_information",
+            "version": "1.0",
+            "sample_cql": "library ifu_information version '1.0'\nusing FHIR version '4.0.1'\ninclude FHIRHelpers version '4.0.1' called FHIRHelpers\ncodesystem \"LOINC\": 'http://loinc.org'\ncontext Patient\ndefine \"ig_death_dx_concept\": Concept {Code '79378-6' from \"LOINC\",Code '92022-3' from \"LOINC\",Code '76060-3' from \"LOINC\",Code '69453-9' from \"LOINC\",Code '76061-1' from \"LOINC\",Code '69441-4' from \"LOINC\",Code '92023-1' from \"LOINC\"} \ndefine \"ig_death\":\n\tcase\n\t\twhen Patient.deceased = true then 'Yes'\n\t\twhen (Patient.deceased as FHIR.dateTime) is not null then 'Yes'\n\t\twhen Patient.deceased = false then 'No'\n\t\telse 'Unknown'\n\tend\ndefine \"ig_death_dx\": [Observation: code ~ \"ig_death_dx_concept\"]\ndefine \"ig_death_dt_dx\": from \"ig_death_dx\" target return ToString((target.effective as FHIR.dateTime).value)\ndefine \"ig_death_dt\":\n\tcase\n\t\twhen (Patient.deceased as FHIR.dateTime) is not null then ToString((Patient.deceased as FHIR.dateTime).value)\n\t\twhen Patient.deceased = false then null\n\t\twhen Patient.deceased = true then 'Unknown'\n\t\twhen exists \"ig_death_dt_dx\" then Combine(\"ig_death_dt_dx\", ',')\n\t\telse 'Not Applicable'\n\tend\ndefine \"ig_death_evidence\": \"ig_death_dx\"\ndefine \"ig_death_dt_evidence\": \"ig_death_evidence\""
+        }
+    ],
+    "nlpql_libraries": [
+        {
+            "name": "ifu_information",
+            "version": "1",
+            "sample_nlpql": "// Phenotype library name\nphenotype \"ifu_information\" version \"1\";\ninclude ClarityCore version \"1.0\" called Clarity;\ntermset ig_death_terms: [\"death\",\"expire\",\"decease\"];\ndefine final ig_death_unstructured: Clarity.ProviderAssertion({termset: [ig_death_terms]});\ndefine final ig_death:Tuple {\"questionConcept\": \"5\",\"answerValue\": ig_death_unstructured.term,\"answerType\": \"ProviderAssertion\",\"sourceNote\": ig_death_unstructured.sentence} where ig_death_unstructured;"
+        }
+    ],
+    "start_jobs_requests": [
+        {
+            "_comment": "A full Parameters POST body to POST /forms/start. Fill in patientId, jobPackage, and job.",
+            "resourceType": "Parameters",
+            "parameter": [
+                {
+                    "name": "patientId",
+                    "valueString": "627902"
+                },
+                {
+                    "name": "jobPackage",
+                    "valueString": "SETNETInfantFollowUp"
+                },
+                {
+                    "name": "job",
+                    "valueString": "ifu_covid_19_module.cql"
+                }
+            ],
+            "expected_output": {
+                "resourceType": "Bundle",
+                "id": "7c9560aa-f176-4501-a401-93442e1c411b",
+                "type": "collection",
+                "entry": [
+                    {
+                        "fullUrl": "Patient/627902",
+                        "resource": {
+                            "resourceType": "Patient",
+                            "id": "627902",
+                            "meta": {
+                                "versionId": "1",
+                                "lastUpdated": "2025-05-06T16:05:10.922+00:00",
+                                "source": "#VA8UUwHAgZxjiVb1"
+                            },
+                            "text": {
+                                "status": "generated",
+                                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div class=\"hapiHeaderText\">Chase <b>CAMPBELL </b></div><table class=\"hapiPropertyTable\"><tbody><tr><td>Identifier</td><td>87654321</td></tr><tr><td>Address</td><td><span>875 WEST PEACHTREE ROAD NORTHEAST </span><br/><span>ATLANTA </span><span>GA </span><span>USA </span></td></tr><tr><td>Date of birth</td><td><span>10 January 2024</span></td></tr></tbody></table></div>"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                                    "extension": [
+                                        {
+                                            "url": "ombCategory",
+                                            "valueCoding": {
+                                                "system": "urn:oid:2.16.840.1.113883.6.238",
+                                                "code": "2106-3",
+                                                "display": "White"
+                                            }
+                                        },
+                                        {
+                                            "url": "text",
+                                            "valueString": "White"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+                                    "extension": [
+                                        {
+                                            "url": "ombCategory",
+                                            "valueCoding": {
+                                                "system": "urn:oid:2.16.840.1.113883.6.238",
+                                                "code": "2186-5",
+                                                "display": "Not Hispanic or Latino"
+                                            }
+                                        },
+                                        {
+                                            "url": "text",
+                                            "valueString": "Not Hispanic or Latino"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "url": "http://open.epic.com/FHIR/StructureDefinition/extension/legal-sex",
+                                    "valueCodeableConcept": {
+                                        "coding": [
+                                            {
+                                                "system": "urn:oid:1.2.840.114350.1.13.244.2.7.10.698084.130.768080.39128",
+                                                "code": "male",
+                                                "display": "male"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/patient-genderIdentity",
+                                    "valueCodeableConcept": {
+                                        "coding": [
+                                            {
+                                                "system": "http://hl7.org/fhir/gender-identity",
+                                                "code": "male",
+                                                "display": "male"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "url": "http://open.epic.com/FHIR/StructureDefinition/extension/sex-for-clinical-use",
+                                    "valueCodeableConcept": {
+                                        "coding": [
+                                            {
+                                                "system": "urn:oid:1.2.840.114350.1.13.244.2.7.10.698084.130.768080.35144",
+                                                "code": "male",
+                                                "display": "male"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                                    "valueDateTime": "2024-01-10T14:53:00+00:00"
+                                }
+                            ],
+                            "identifier": [
+                                {
+                                    "use": "usual",
+                                    "type": {
+                                        "text": "GA8"
+                                    },
+                                    "system": "urn:oid:1.2.840.114350.1.13.876.1.4.8.725198.0",
+                                    "value": "87654321"
+                                }
+                            ],
+                            "active": true,
+                            "name": [
+                                {
+                                    "use": "official",
+                                    "text": "Chase Campbell",
+                                    "family": "Campbell",
+                                    "given": [
+                                        "Chase"
+                                    ]
+                                }
+                            ],
+                            "telecom": [
+                                {
+                                    "system": "phone",
+                                    "value": "404-678-9876",
+                                    "use": "home"
+                                }
+                            ],
+                            "gender": "male",
+                            "birthDate": "2024-01-10",
+                            "address": [
+                                {
+                                    "use": "home",
+                                    "line": [
+                                        "875 WEST PEACHTREE ROAD NORTHEAST"
+                                    ],
+                                    "city": "ATLANTA",
+                                    "district": "FULTON",
+                                    "state": "GA",
+                                    "postalCode": "30308",
+                                    "country": "USA"
+                                }
+                            ],
+                            "maritalStatus": {
+                                "text": "Single"
+                            },
+                            "multipleBirthInteger": 1,
+                            "communication": [
+                                {
+                                    "language": {
+                                        "coding": [
+                                            {
+                                                "system": "urn:ietf:bcp:47",
+                                                "code": "en",
+                                                "display": "English"
+                                            }
+                                        ]
+                                    },
+                                    "preferred": true
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "fullUrl": "Observation/5bdb345a-d577-493f-8e5f-a81969c4f9e0",
+                        "resource": {
+                            "resourceType": "Observation",
+                            "id": "5bdb345a-d577-493f-8e5f-a81969c4f9e0",
+                            "identifier": [
+                                {
+                                    "system": "https://smartchartsuite.dev.heat.icl.gtri.org/rc-api/",
+                                    "value": "Observation/5bdb345a-d577-493f-8e5f-a81969c4f9e0"
+                                }
+                            ],
+                            "status": "final",
+                            "category": [
+                                {
+                                    "coding": [
+                                        {
+                                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                                            "code": "survey",
+                                            "display": "Survey"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "code": {
+                                "coding": [
+                                    {
+                                        "system": "urn:gtri:heat:form:SETNETInfantFollowUp",
+                                        "code": "62",
+                                        "display": "Did the infant have jaundice requiring phototherapy after birth hospitalization?"
+                                    }
+                                ]
+                            },
+                            "subject": {
+                                "reference": "Patient/627902"
+                            },
+                            "focus": [
+                                {
+                                    "reference": "Condition/a06d1f28-0fa8-4e4a-9c92-4f841b12c1f0"
+                                }
+                            ],
+                            "effectiveDateTime": "2026-03-03T14:16:35Z"
+                        }
+                    },
+                    {
+                        "fullUrl": "Condition/a06d1f28-0fa8-4e4a-9c92-4f841b12c1f0",
+                        "resource": {
+                            "resourceType": "Condition",
+                            "id": "a06d1f28-0fa8-4e4a-9c92-4f841b12c1f0",
+                            "meta": {
+                                "versionId": "1",
+                                "lastUpdated": "2025-05-12T20:32:46.903+00:00",
+                                "source": "#1oavnQAhg9J3JcG8",
+                                "profile": [
+                                    "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+                                ]
+                            },
+                            "clinicalStatus": {
+                                "coding": [
+                                    {
+                                        "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                                        "code": "active",
+                                        "display": "Active"
+                                    }
+                                ]
+                            },
+                            "verificationStatus": {
+                                "coding": [
+                                    {
+                                        "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                                        "code": "confirme",
+                                        "display": "Confirmed"
+                                    }
+                                ]
+                            },
+                            "category": [
+                                {
+                                    "coding": [
+                                        {
+                                            "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                                            "code": "encounter-diagnosis",
+                                            "display": "Encounter Diagnosis"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "code": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+                                        "code": "P59.9",
+                                        "display": "Neonatal jaundice, unspecified"
+                                    }
+                                ]
+                            },
+                            "subject": {
+                                "reference": "Patient/627902"
+                            },
+                            "encounter": {
+                                "reference": "Encounter/c9683c13-8ea3-4102-90a0-303595172a5e"
+                            },
+                            "onsetDateTime": "2024-01-12T00:00:00+00:00"
+                        }
+                    }
+                ],
+                "total": 3
+            }
+        }
+    ],
+    "batch_jobs_requests": [
+        {
+            "_comment": "A full Parameters POST body to POST /smartchartui/batchjob.",
+            "resourceType": "Parameters",
+            "parameter": [
+                {
+                    "name": "patientId",
+                    "valueString": "627902"
+                },
+                {
+                    "name": "jobPackage",
+                    "valueString": "SETNETInfantFollowUpIntegrationTesting"
+                }
+            ]
+        }
+    ],
+    "jobpackage_csv_samples": [
+        {
+            "_comment": "A CSV string for POST /forms/jobPackageToQuestionnaire. Paste the full CSV content in 'csv'.",
+            "csv": "NAME:,Syphilis Registry,,,,,,,,,,,,,,,,,,,,,,,,,,,\nVERSION:,0.3,,,,,,,,,,,,,,,,,,,,,,,,,,,\nDESCRIPTION:,Package for Syphilis Registry,,,,,,,,,,,,,,,,,,,,,,,,,,,\nQuestion Text,Group,LinkID,Task Type,CQL Library,CQL Definition,Cardinality,Item/Answer Type,AnswerOption (Choice Only),Notes (Not Parsed),GitHub location,Atlas location,,,,,,,,,,,,,,,,,\nFirst Name,Demographics,2000000001,CQL,demographics,first_name,single,string,,,,,,,,,,,,,,,,,,,,,\nLast Name,Demographics,2000000002,CQL,demographics,last_name,single,string,,,,,https://atlas-demo.ohdsi.org/#/conceptset/1870997/expression,,,,,,,,,,,,,,,,\nDOB,Demographics,2000000003,CQL,demographics,date_of_birth,single,string,,,,,https://atlas-demo.ohdsi.org/#/conceptset/1870998/expression,,,,,,,,,,,,,,,,\nAge,Demographics,2000000004,CQL,demographics,age,single,string,,,,,https://atlas-demo.ohdsi.org/#/conceptset/1870999/expression,,,,,,,,,,,,,,,,\nGender,Demographics,2000000005,CQL,demographics,gender,single,string,,,,,,,,,,,,,,,,,,,,,\nRace,Demographics,2000000006,CQL,demographics,race,single,string,,,,,,,,,,,,,,,,,,,,,\nEthnicity,Demographics,2000000007,CQL,demographics,ethnicity,single,string,,,,,,,,,,,,,,,,,,,,,\nTest Results,Testing,display1,,,,,display,,Display Item,,,,,,,,,,,,,,,,,,,\nLab Results,Lab Results,2000000008,CQL,Syphilis_Lab_Results,lab_results,series,string,,Will contain Date / Test Codesystem / Code / Name / Result / Units,\"\"\"10/14/2020^http://loinc.org^1234-5^Rapid Plasma Reagin^Positive\"\"\",https://atlas-demo.ohdsi.org/#/conceptset/1870999/expression,,,,,,,,,,,,,,,,,\nRelated Lab Results,Lab Results,2000000009,CQL,Syphilis_Lab_Results,syphilis_related_labs,series,string,,Will contain Date / Test Codesystem / Code / Name / Result / Units,\"\"\"10/14/2020^http://loinc.org^7918-6^HIV 1+2 Ab [Presence] in Serum^Negative\"\"\",,,,,,,,,,,,,,,,,,\nDiagnoses,Diagnoses,display2,,,,,display,,,,,,,,,,,,,,,,,,,,,\nSyphilis Diagnoses,Diagnoses,2000000010,CQL,Syphilis_Diagnoses,syphilis_diagnoses,series,string,,Will contain Date / Codesystem / Code / Name,\"\"\"07/21/2019^ICD9^362.2^Neurosyphilis\"\"\",https://atlas-demo.ohdsi.org/#/conceptset/1870999/expression,,,,,,,,,,,,,,,,,\nSyphilis DIagnoses,Diagnoses,2000000010,NLPQL,Syphilis_Diagnoses,syphilis_diagnoses,series,string,,Will contain Date^Concept Name^text,\"\"\"07/21/2020^Syphilis^Patient diagnosed with Syphilis\"\"\",,,,,,,,,,,,,,,,,,\nSymptoms,Diagnoses,2000000012,CQL,Syphilis_Diagnoses,syphilis_symptoms,series,string,,Will contain Date / Codesystem / Code / Name,\"\"\"07/21/2020^ICD10^E210^Mental Status Changes\"\"\",,,,,,,,,,,,,,,,,,\nSymptoms,Diagnoses,2000000012,NLPQL,Syphilis_Symptoms,syphilis_symptoms,series,string,,,,,,,,,,,,,,,,,,,,,\nPotential Complications,Diagnoses,2000000020,CQL,,,series,string,,,,,,,,,,,,,,,,,,,,,\nPotential Complications,Diagnoses,2000000020,NLPQL,,,series,string,,,,,,,,,,,,,,,,,,,,,\nComorbid Conditions,Diagnoses,2000000011,CQL,Syphilis_Related_Diagnoses,syphilis_related_diagnoses,series,,,,,https://atlas-demo.ohdsi.org/#/conceptset/1870997/expression,,,,,,,,,,,,,,,,,\nComorbid Conditions,Diagnoses,2000000011,NLPQL,Syphilis_Related_Diagnoses,syphilis_related_diagnoses,series,string,,,,,,,,,,,,,,,,,,,,,\nBehaviorial Factor,Diagnoses,2000000022,CQL,Syphilis_Related_Diagnoses,syphilis_behavioral_factors,series,string,,,,https://atlas-demo.ohdsi.org/#/conceptset/1870998/expression,,,,,,,,,,,,,,,,,\nBehaviorial Factor,Diagnoses,2000000022,NLPQL,Syphilis_Related_Diagnoses,syphilis_behavioral_factors,series,string,,,,,,,,,,,,,,,,,,,,,\nTreatments,Treatment,display2,,,,,display,,,,,,,,,,,,,,,,,,,,,\nSyphilis Treatment,Treatment,2000000013,CQL,Syphilis_Treatment,syphilis_treatment,series,string,,Will contain Date / Codesystem / Code / Name / Dose / Units,\"\"\"09/21/2020^RxNorm^123345^Penicillin G^1000^milligram\"\"\",,,,,,,,,,,,,,,,,,\nSyphilis Treatment,Treatment,2000000013,NLPQL,Syphilis_Treatment,syphilis_treatment,series,string,,,,,,,,,,,,,,,,,,,,,\nPregnancy,Pregnancy,display2,,,,,display,,,,,,,,,,,,,,,,,,,,,\nLast Menstrual Period,Pregnancy,2000000014,CQL,Pregnancy,lmp,series,display,,,,,,,,,,,,,,,,,,,,,\nLast Menstrual Period,Pregnancy,2000000014,NLPQL,Pregnancy,lmp,series,display,,,,,,,,,,,,,,,,,,,,,\nPregnant,Pregnancy,2000000015,CQL,Pregnancy,pregnant,series,string,,,,,,,,,,,,,,,,,,,,,\nPregnant,Pregnancy,2000000015,NLPQL,Pregnancy,pregnant,series,string,,,,,,,,,,,,,,,,,,,,,\nPrenatal Care,Pregnancy,2000000016,CQL,Pregnancy,prenatal_care_afp,series,string,,,,,,,,,,,,,,,,,,,,,\nPrenatal Care,Pregnancy,2000000016,CQL,Pregnancy,prenatal_care,series,string,,,,,,,,,,,,,,,,,,,,,\nPrenatal Care,Pregnancy,2000000016,NLPQL,Pregnancy,prenatal_care,series,string,,,,,,,,,,,,,,,,,,,,,\nPregnancy Test,Pregnancy,2000000017,CQL,Pregnancy,pregnancy_test,series,string,,,,,,,,,,,,,,,,,,,,,\nPregnancy Test,Pregnancy,2000000017,NLPQL,Pregnancy,pregnancy_test,series,string,,,,,,,,,,,,,,,,,,,,,\nDelivery Related,Pregnancy,2000000018,CQL,Pregnancy,delivery_related,series,string,,,,,,,,,,,,,,,,,,,,,\nDelivery Related,Pregnancy,2000000018,NLPQL,Pregnancy,delivery_related,series,string,,,,,,,,,,,,,,,,,,,,,\nTermination,Pregnancy,2000000019,CQL,Pregnancy,termination_observation,series,string,,,,,,,,,,,,,,,,,,,,,",
+            "cql_only": false,
+            "smartchart": false,
+            "expected_resource_type": "Questionnaire"
+        }
+    ]
+}

--- a/tests/test_cql_router.py
+++ b/tests/test_cql_router.py
@@ -1,0 +1,177 @@
+"""
+Tests for cql_router.py
+Endpoints covered:
+  GET  /forms/cql
+  GET  /forms/cql/{library_name}
+  POST /forms/cql
+  PUT  /forms/cql/{library_name}
+"""
+
+import base64
+from unittest.mock import patch
+
+from tests.conftest import load_fixture, make_fhir_searchset, make_response
+
+# ---------------------------------------------------------------------------
+# Shared helper: a minimal valid CQL string
+# ---------------------------------------------------------------------------
+VALID_CQL = "library TestLibrary version '1.0.0'\nusing FHIR version '4.0.1'\ncontext Patient"
+
+
+class TestGetCqlLibraries:
+    def test_get_cql_libraries_success(self, client, mock_httpx):
+        """GET /forms/cql → 200 with Bundle when CQF Ruler returns data."""
+        cql_lib = load_fixture("fhir_library_cql")
+        bundle = make_fhir_searchset([cql_lib])
+        mock_httpx.get.return_value = make_response(200, bundle)
+
+        response = client.get("/forms/cql")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Bundle"
+        assert body["total"] == 1
+
+    def test_get_cql_libraries_server_error(self, client, mock_httpx):
+        """GET /forms/cql → OperationOutcome when CQF Ruler returns 500."""
+        mock_httpx.get.return_value = make_response(500, {"error": "server error"})
+
+        response = client.get("/forms/cql")
+        assert response.status_code == 200  # Router returns OO in 200 body
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "transient"
+
+    def test_get_cql_libraries_empty_bundle(self, client, mock_httpx):
+        """GET /forms/cql → 200 with empty Bundle when no libraries exist."""
+        empty = load_fixture("fhir_bundle_empty")
+        mock_httpx.get.return_value = make_response(200, empty)
+
+        response = client.get("/forms/cql")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 0
+
+
+class TestGetCqlByName:
+    def test_get_cql_by_name_returns_plain_text(self, client, mock_httpx):
+        """GET /forms/cql/{name} → plain text CQL when library found."""
+        cql_lib = load_fixture("fhir_library_cql")
+        bundle = make_fhir_searchset([cql_lib])
+        mock_httpx.get.return_value = make_response(200, bundle)
+
+        response = client.get("/forms/cql/TestLibrary")
+        assert response.status_code == 200
+        expected_cql = base64.b64decode(cql_lib["content"][0]["data"]).decode("utf-8")
+        assert response.text == expected_cql
+
+    def test_get_cql_by_name_not_found(self, client, mock_httpx):
+        """GET /forms/cql/{name} → OperationOutcome not-found when no match."""
+        empty = load_fixture("fhir_bundle_empty")
+        mock_httpx.get.return_value = make_response(200, empty)
+
+        response = client.get("/forms/cql/NonExistentLibrary")
+        # When empty bundle returned, router returns not-found OperationOutcome as a plain dict
+        # The response type may be application/fhir+json — check that we get a valid OO
+        assert response.status_code in (200, 500)  # Router either returns OO or raises exception
+        if response.status_code == 200:
+            body = response.json()
+            assert body["resourceType"] == "OperationOutcome"
+            assert body["issue"][0]["code"] == "not-found"
+
+    def test_get_cql_server_error(self, client, mock_httpx):
+        """GET /forms/cql/{name} → OperationOutcome transient on server error."""
+        mock_httpx.get.return_value = make_response(503, {})
+
+        response = client.get("/forms/cql/TestLibrary")
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "transient"
+
+
+class TestSaveCql:
+    def test_save_cql_success(self, client, mock_httpx):
+        """POST /forms/cql → 201 OperationOutcome on successful save."""
+        empty = load_fixture("fhir_bundle_empty")
+        post_response_body = {"id": "new-lib-id-001"}
+
+        mock_httpx.get.return_value = make_response(200, empty)
+        mock_httpx.post.return_value = make_response(201, post_response_body)
+
+        # Use unittest.mock.patch (thread-safe across anyio threadpool)
+        with patch("src.services.libraryhandler.validate_cql", return_value=True):
+            response = client.post("/forms/cql", content=VALID_CQL, headers={"Content-Type": "text/plain"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["severity"] == "information"
+        assert "new-lib-id-001" in body["issue"][0]["diagnostics"]
+
+    def test_save_cql_updates_existing_library(self, client, mock_httpx, monkeypatch):
+        """POST /forms/cql → uses PUT when library already exists, returns 201."""
+        cql_lib = load_fixture("fhir_library_cql")
+        existing_bundle = make_fhir_searchset([cql_lib])
+        put_response = {"id": "test-cql-library-001"}
+
+        mock_httpx.get.return_value = make_response(200, existing_bundle)
+        mock_httpx.put.return_value = make_response(200, put_response)
+
+        with patch("src.services.libraryhandler.validate_cql", return_value=True):
+            response = client.post("/forms/cql", content=VALID_CQL, headers={"Content-Type": "text/plain"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+    def test_save_cql_validation_error_returned(self, client, mock_httpx):
+        """POST /forms/cql → OperationOutcome 500 when CQL validation fails."""
+        error_oo = {"resourceType": "OperationOutcome", "issue": [{"severity": "error", "code": "invalid", "diagnostics": "Syntax error"}]}
+        with patch("src.services.libraryhandler.validate_cql", return_value=error_oo):
+            response = client.post("/forms/cql", content=VALID_CQL, headers={"Content-Type": "text/plain"})
+        body = response.json()
+        assert response.status_code == 500
+        assert body["resourceType"] == "OperationOutcome"
+
+    def test_save_cql_empty_body_rejected(self, client):
+        """POST /forms/cql with empty body → 400 OperationOutcome (custom handler)."""
+        response = client.post("/forms/cql", content="", headers={"Content-Type": "text/plain"})
+        # The app's custom exception handler converts FastAPI's 422 to 400 OperationOutcome
+        assert response.status_code == 400
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+    def test_save_cql_cqf_ruler_post_error(self, client, mock_httpx):
+        """POST /forms/cql → OperationOutcome 500 when CQF Ruler POST fails."""
+        empty = load_fixture("fhir_bundle_empty")
+        mock_httpx.get.return_value = make_response(200, empty)
+        mock_httpx.post.return_value = make_response(500, {"error": "internal error"})
+
+        with patch("src.services.libraryhandler.validate_cql", return_value=True):
+            response = client.post("/forms/cql", content=VALID_CQL, headers={"Content-Type": "text/plain"})
+        body = response.json()
+        assert response.status_code == 500
+        assert body["resourceType"] == "OperationOutcome"
+
+
+class TestUpdateCql:
+    def test_update_cql_success(self, client, mock_httpx, monkeypatch):
+        """PUT /forms/cql/{name} → 201 OperationOutcome on successful update."""
+        monkeypatch.setattr("src.services.libraryhandler.validate_cql", lambda code: True)
+
+        cql_lib = load_fixture("fhir_library_cql")
+        existing_bundle = make_fhir_searchset([cql_lib])
+        put_response = {"id": "test-cql-library-001"}
+
+        mock_httpx.get.return_value = make_response(200, existing_bundle)
+        mock_httpx.put.return_value = make_response(200, put_response)
+
+        response = client.put("/forms/cql/TestLibrary", content=VALID_CQL, headers={"Content-Type": "text/plain"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["severity"] == "information"
+
+    def test_update_cql_empty_body_rejected(self, client):
+        """PUT /forms/cql/{name} with empty body → 400 OperationOutcome (custom handler)."""
+        response = client.put("/forms/cql/TestLibrary", content="", headers={"Content-Type": "text/plain"})
+        assert response.status_code == 400
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"

--- a/tests/test_forms_router.py
+++ b/tests/test_forms_router.py
@@ -1,0 +1,293 @@
+"""
+Tests for forms_router.py
+Endpoints covered:
+  GET  /forms
+  GET  /forms/{form_name}
+  POST /forms
+  PUT  /forms/{form_name}
+  POST /forms/start
+  GET  /forms/status/all
+  GET  /forms/status/{uid}
+  POST /forms/jobPackageToQuestionnaire
+"""
+
+import uuid
+
+import pytest
+
+from tests.conftest import load_fixture, load_user_data, make_fhir_searchset, make_response
+
+# ---------------------------------------------------------------------------
+# Sample StartJobsParameters body
+# ---------------------------------------------------------------------------
+START_JOBS_BODY = {
+    "resourceType": "Parameters",
+    "parameter": [
+        {"name": "patientId", "valueString": "test-patient-001"},
+        {"name": "jobPackage", "valueString": "TestQuestionnaire"},
+        {"name": "job", "valueString": "TestLibrary.cql"},
+    ],
+}
+
+
+class TestGetForms:
+    def test_get_forms_success(self, client, mock_httpx, monkeypatch):
+        """GET /forms → 200 Bundle of Questionnaires."""
+        monkeypatch.setenv("CQF_RULER_R4", "http://localhost:8080/fhir/")
+        questionnaire = load_fixture("fhir_questionnaire")
+        bundle = make_fhir_searchset([questionnaire])
+        mock_httpx.get.return_value = make_response(200, bundle)
+
+        response = client.get("/forms")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Bundle"
+
+    def test_get_forms_server_error(self, client, mock_httpx, monkeypatch):
+        """GET /forms → OperationOutcome when CQF Ruler is unavailable."""
+        monkeypatch.setenv("CQF_RULER_R4", "http://localhost:8080/fhir/")
+        mock_httpx.get.return_value = make_response(503, {})
+
+        response = client.get("/forms")
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "transient"
+
+
+class TestGetFormByName:
+    def test_get_form_by_name_success(self, client, mock_httpx):
+        """GET /forms/{name} → returns Questionnaire dict when found."""
+        questionnaire = load_fixture("fhir_questionnaire")
+        bundle = make_fhir_searchset([questionnaire])
+        # get_form in src.models.forms uses its own httpx_client (already in mock_httpx targets)
+        mock_httpx.get.return_value = make_response(200, bundle)
+
+        response = client.get("/forms/TestQuestionnaire")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Questionnaire"
+        assert body["name"] == "TestQuestionnaire"
+
+    def test_get_form_by_name_not_found(self, client, mock_httpx):
+        """GET /forms/{name} → OperationOutcome not-found when form doesn't exist."""
+        empty = load_fixture("fhir_bundle_empty")
+        mock_httpx.get.return_value = make_response(200, empty)
+
+        response = client.get("/forms/NotAForm")
+        # get_form returns OperationOutcome dict when not found (200 with OO body)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "not-found"
+
+
+class TestSaveForm:
+    def test_save_form_success(self, client, mock_httpx):
+        """POST /forms → OperationOutcome when Questionnaire posted to CQF Ruler OK."""
+        questionnaire = load_fixture("fhir_questionnaire")
+        # save_form_questionnaire: GET (check exists) → empty+KeyError; POST → 201
+        # NOTE: The empty bundle causes KeyError in save_form_questionnaire which is caught
+        # and triggers a POST rather than a 'duplicate' response.
+        empty = load_fixture("fhir_bundle_empty")
+        mock_httpx.get.return_value = make_response(200, empty)
+        mock_httpx.post.return_value = make_response(201, {"id": "new-q-001"})
+
+        response = client.post("/forms", json=questionnaire)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        # save_form_questionnaire returns an informational OO on success
+        assert body["issue"][0]["severity"] in ("information", "informational")
+
+
+class TestUpdateForm:
+    def test_update_form_success(self, client, mock_httpx):
+        """PUT /forms/{name} → OperationOutcome success when Questionnaire updated."""
+        questionnaire = load_fixture("fhir_questionnaire")
+        bundle = make_fhir_searchset([questionnaire])
+        mock_httpx.get.return_value = make_response(200, bundle)
+        mock_httpx.put.return_value = make_response(200, {"id": questionnaire["id"]})
+
+        response = client.put("/forms/TestQuestionnaire", json=questionnaire)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["severity"] == "information"
+
+    def test_update_form_not_found(self, client, mock_httpx):
+        """PUT /forms/{name} → OperationOutcome not-found or 500 when entry not in bundle.
+
+        NOTE: The empty bundle causes the same IndexError as in get_form not-found.
+        This is a known production bug in get_update_questionnaire.
+        """
+        empty = load_fixture("fhir_bundle_empty")
+        mock_httpx.get.return_value = make_response(200, empty)
+
+        questionnaire = load_fixture("fhir_questionnaire")
+        response = client.put("/forms/NonExistent", json=questionnaire)
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+    def test_update_form_cqf_ruler_get_error(self, client, mock_httpx):
+        """PUT /forms/{name} → OperationOutcome transient when CQF Ruler GET fails."""
+        mock_httpx.get.return_value = make_response(500, {})
+
+        questionnaire = load_fixture("fhir_questionnaire")
+        response = client.put("/forms/TestQuestionnaire", json=questionnaire)
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "transient"
+
+
+class TestStartJobs:
+    def test_start_jobs_sync_calls_start_jobs(self, client, monkeypatch):
+        """POST /forms/start (sync) → calls start_jobs and returns its result."""
+        mock_result = {"resourceType": "Bundle", "type": "collection", "entry": []}
+
+        async def mock_start_jobs(post_body):
+            return mock_result
+
+        monkeypatch.setattr("src.routers.forms_router.start_jobs", mock_start_jobs)
+
+        response = client.post("/forms/start", json=START_JOBS_BODY)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Bundle"
+
+    def test_start_jobs_async_creates_job_entry(self, client, monkeypatch):
+        """POST /forms/start?asyncFlag=true → returns ParametersJob with jobId and Location header."""
+
+        async def mock_start_jobs(post_body):
+            return {"resourceType": "Bundle"}
+
+        monkeypatch.setattr("src.routers.forms_router.start_jobs", mock_start_jobs)
+
+        response = client.post("/forms/start?asyncFlag=true", json=START_JOBS_BODY)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Parameters"
+        # Verify jobId is in the response parameters
+        param_names = [p["name"] for p in body["parameter"]]
+        assert "jobId" in param_names
+        assert "Location" in response.headers
+
+    def test_start_jobs_missing_required_fields(self, client):
+        """POST /forms/start with incomplete body → 400 or 422 validation error."""
+        response = client.post("/forms/start", json={"resourceType": "Parameters"})
+        # FastAPI returns 422 for Pydantic validation failures
+        assert response.status_code in (400, 422)
+
+
+class TestJobStatus:
+    def test_get_all_jobs_empty(self, client, monkeypatch):
+        """GET /forms/status/all → empty dict when no jobs are running."""
+        # The jobs dict in forms_router is module-level; reset it
+        import src.routers.forms_router as forms_router
+
+        monkeypatch.setattr(forms_router, "jobs", {})
+        response = client.get("/forms/status/all")
+        assert response.status_code == 200
+        assert response.json() == {}
+
+    def test_get_job_status_not_found(self, client, monkeypatch):
+        """GET /forms/status/{uid} → 404 OperationOutcome when uid not in jobs."""
+        import src.routers.forms_router as forms_router
+
+        monkeypatch.setattr(forms_router, "jobs", {})
+        response = client.get("/forms/status/nonexistent-uid")
+        assert response.status_code == 404
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "code-invalid"
+
+    def test_get_job_status_found_in_progress(self, client, monkeypatch):
+        """GET /forms/status/{uid} → returns ParametersJob dict for known uid."""
+        import src.routers.forms_router as forms_router
+        from src.models.models import ParametersJob
+
+        job_id = str(uuid.uuid4())
+        test_job = ParametersJob()
+        for param in test_job.parameter:
+            if param.name == "jobId":
+                param.valueString = job_id
+
+        monkeypatch.setattr(forms_router, "jobs", {job_id: test_job})
+        response = client.get(f"/forms/status/{job_id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Parameters"
+
+
+class TestJobPackageToQuestionnaire:
+    def test_convert_jobpackage_invalid_csv(self, client, monkeypatch):
+        """POST /forms/jobPackageToQuestionnaire with invalid CSV → error response."""
+        monkeypatch.setattr(
+            "src.routers.forms_router.convert_jobpackage_csv_to_questionnaire",
+            lambda **kwargs: {"resourceType": "OperationOutcome", "issue": [{"severity": "error", "code": "invalid", "diagnostics": "Invalid CSV"}]},
+        )
+        response = client.post(
+            "/forms/jobPackageToQuestionnaire",
+            content="NOT_VALID_CSV",
+            headers={"Content-Type": "text/plain"},
+        )
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+    def test_convert_jobpackage_returns_questionnaire(self, client, monkeypatch):
+        """POST /forms/jobPackageToQuestionnaire → Questionnaire resource on success."""
+        questionnaire = load_fixture("fhir_questionnaire")
+        monkeypatch.setattr(
+            "src.routers.forms_router.convert_jobpackage_csv_to_questionnaire",
+            lambda **kwargs: questionnaire,
+        )
+        response = client.post(
+            "/forms/jobPackageToQuestionnaire",
+            content="some,csv,data",
+            headers={"Content-Type": "text/plain"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Questionnaire"
+
+    def test_convert_jobpackage_with_commit_false(self, client, monkeypatch):
+        """POST /forms/jobPackageToQuestionnaire?commit=false → returns Questionnaire not OO."""
+        questionnaire = load_fixture("fhir_questionnaire")
+        monkeypatch.setattr(
+            "src.routers.forms_router.convert_jobpackage_csv_to_questionnaire",
+            lambda **kwargs: questionnaire,
+        )
+        response = client.post(
+            "/forms/jobPackageToQuestionnaire?commit=false",
+            content="some,csv,data",
+            headers={"Content-Type": "text/plain"},
+        )
+        body = response.json()
+        assert body["resourceType"] == "Questionnaire"
+
+
+# ---------------------------------------------------------------------------
+# Data-driven tests using user_data.json (skip if placeholders not filled in)
+# ---------------------------------------------------------------------------
+class TestStartJobsUserData:
+    @pytest.mark.parametrize("scenario", load_user_data().get("start_jobs_requests", []))
+    def test_start_jobs_with_real_data(self, client, monkeypatch, scenario):
+        """POST /forms/start with user-provided data → expected output shape."""
+        if scenario["parameter"][0]["valueString"] == "REPLACE_ME":
+            pytest.skip("User data not yet populated in tests/fixtures/user_data.json")
+
+        expected = scenario.get("expected_output", {})
+        expected_resource_type = expected.get("resourceType", "Bundle")
+
+        async def mock_start_jobs(post_body):
+            return expected
+
+        monkeypatch.setattr("src.routers.forms_router.start_jobs", mock_start_jobs)
+
+        body = {
+            "resourceType": scenario["resourceType"],
+            "parameter": scenario["parameter"],
+        }
+        response = client.post("/forms/start", json=body)
+        assert response.status_code == 200
+        resp_body = response.json()
+        assert resp_body["resourceType"] == expected_resource_type

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,464 @@
+"""
+test_integration.py — End-to-end tests requiring real external services.
+
+These tests hit REAL instances of:
+  - CQF Ruler (CQF_RULER_R4 env var)
+  - External FHIR server (EXTERNAL_FHIR_SERVER_URL env var)
+  - DB (DB_CONNECTION_STRING env var)
+
+They are decorated with @pytest.mark.integration and are SKIPPED by default.
+
+How to run:
+  conda activate rcapi
+  python -m pytest tests/test_integration.py -v -s -m integration
+
+Input data comes from tests/fixtures/user_data.json:
+  - "start_jobs_requests"   → list of Parameters POST bodies for POST /forms/start
+  - "batch_jobs_requests"   → list of Parameters POST bodies for POST /smartchartui/batchjob
+
+Logging strategy:
+  Each test prints explicit step-by-step output (pytest -s) so that when an external service is broken you can see exactly which call failed, what the status code was, and what body was returned
+  without having to re-run in debug mode.
+"""
+
+import json
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+from loguru import logger
+
+from tests.conftest import load_user_data
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+BATCH_JOB_POLL_INTERVAL_SECONDS = 10
+BATCH_JOB_POLL_TIMEOUT_SECONDS = 300  # 5 minutes
+BATCH_JOB_MIN_RESULT_ENTRIES = 10  # at least 10 entries (Patient + observations)
+
+STATUS_OBS_FULL_URL = "Observation/status-observation"
+STATUS_OBS_COMPLETE_CODE = "complete"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+# Modules that bind cqfr4_fhir / external_fhir_server_url at import time.
+# ALL of them must be patched so the app's outbound httpx calls reach real servers.
+_CQFR4_TARGETS = [
+    "src.util.settings.cqfr4_fhir",
+    "src.routers.cql_router.cqfr4_fhir",
+    "src.routers.nlpql_router.cqfr4_fhir",
+    "src.routers.forms_router.cqfr4_fhir",
+    "src.services.libraryhandler.cqfr4_fhir",
+    "src.models.forms.cqfr4_fhir",
+    "src.models.functions.cqfr4_fhir",
+    "src.routers.smartchartui.internal_fhir_client.server_base",
+]
+_FHIR_SERVER_TARGETS = [
+    "src.util.settings.external_fhir_server_url",
+    "src.models.functions.external_fhir_server_url",
+    "src.routers.smartchartui.external_fhir_client.server_base",
+]
+_FHIR_AUTH_TARGETS = [
+    "src.util.settings.external_fhir_server_auth",
+    "src.models.functions.external_fhir_server_auth",
+]
+_NLPAAS_TARGETS = [
+    "src.util.settings.nlpaas_url",
+    "src.services.libraryhandler.nlpaas_url",
+    "src.util.git.nlpaas_url",
+    "src.models.functions.nlpaas_url",
+]
+
+# ---------------------------------------------------------------------------
+# Integration Questionnaire fixture path
+# ---------------------------------------------------------------------------
+_INTEGRATION_QUESTIONNAIRE_PATH = os.path.join(os.path.dirname(__file__), "fixtures", "fhir_integration_questionnaire.json")
+_INTEGRATION_QUESTIONNAIRE_NAME = "SETNETInfantFollowUpIntegrationTesting"
+
+
+# Shared state written by the setup fixture so tests can record batch job IDs
+# that need to be cleaned up on teardown.
+_batch_ids_to_cleanup: list[str] = []
+
+
+def _load_env_file(path: str) -> dict[str, str]:
+    """
+    Parse a .env file and return a dict of key=value pairs.
+    Ignores comment lines (#) and blank lines. No dependency on python-dotenv.
+    """
+    env: dict[str, str] = {}
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" in line:
+                    key, _, value = line.partition("=")
+                    env[key.strip()] = value.strip()
+    except FileNotFoundError:
+        pass
+    return env
+
+
+@pytest.fixture(scope="module")
+def integration_client():
+    """
+    TestClient wired to REAL external services.
+
+    Service URLs are read from .env in the repo root (gitignored).
+    Every module-scope import of cqfr4_fhir / external_fhir_server_url is patched so outbound
+    httpx calls reach the real servers instead of the localhost test defaults.
+
+    Setup (before yield):
+      - Upload fhir_integration_questionnaire.json to CQF Ruler so the batch job tests can
+        reference it by name (SETNETInfantFollowUpIntegrationTesting).
+
+    Teardown (after yield, while TestClient + patches are still active):
+      - Delete the uploaded Questionnaire from CQF Ruler.
+      - Delete any batch jobs recorded in _batch_ids_to_cleanup via DELETE /smartchartui/batchjob/{id}.
+
+    Auto-skips if .env doesn't exist or URLs are still placeholders.
+    """
+    import contextlib
+    import httpx as _httpx
+
+    env_file = os.path.join(os.path.dirname(__file__), "..", ".env")
+    svc = _load_env_file(os.path.normpath(env_file))
+
+    cqf_url = svc.get("CQF_RULER_R4", "")
+    fhir_url = svc.get("EXTERNAL_FHIR_SERVER_URL", "")
+    fhir_auth = svc.get("EXTERNAL_FHIR_SERVER_AUTH", "")
+    nlpaas_url = svc.get("NLPAAS_URL", "")
+    db_conn = svc.get("DB_CONNECTION_STRING", "")
+
+    if not cqf_url or "REPLACE_ME" in cqf_url:
+        pytest.skip(".env not found or CQF_RULER_R4 not set. Copy .env.example → .env and fill in real service URLs.")
+    if not fhir_url or "REPLACE_ME" in fhir_url:
+        pytest.skip(".env not found or EXTERNAL_FHIR_SERVER_URL not set. Copy .env.example → .env and fill in real service URLs.")
+
+    if not cqf_url.endswith("/"):
+        cqf_url += "/"
+    if not fhir_url.endswith("/"):
+        fhir_url += "/"
+    if nlpaas_url and nlpaas_url.lower() != "false" and not nlpaas_url.endswith("/"):
+        nlpaas_url += "/"
+    if nlpaas_url.lower() == "false":
+        nlpaas_url = ""
+
+    logger.info(f"[INTEGRATION] CQF Ruler:      {cqf_url}")
+    logger.info(f"[INTEGRATION] External FHIR:  {fhir_url}")
+    if nlpaas_url:
+        logger.info(f"[INTEGRATION] NLPaaS:         {nlpaas_url}")
+
+    # ── Setup: upload the integration questionnaire to CQF Ruler ────────────
+    with open(_INTEGRATION_QUESTIONNAIRE_PATH) as f:
+        questionnaire_body = json.load(f)
+
+    logger.info(f"\n[INTEGRATION SETUP] Uploading Questionnaire '{_INTEGRATION_QUESTIONNAIRE_NAME}' to CQF Ruler...")
+    upload_resp = _httpx.post(
+        f"{cqf_url}Questionnaire",
+        json=questionnaire_body,
+        headers={"Content-Type": "application/fhir+json"},
+        timeout=30,
+    )
+    if upload_resp.status_code not in (200, 201):
+        pytest.fail(f"[INTEGRATION SETUP] Failed to upload integration Questionnaire to CQF Ruler — status={upload_resp.status_code}, body={upload_resp.text[:500]}")
+
+    questionnaire_server_id = upload_resp.json().get("id")
+    logger.info(f"\n[INTEGRATION SETUP] Questionnaire uploaded — server ID: {questionnaire_server_id}")
+
+    # Build URL patches — all modules that imported cqfr4_fhir / external_fhir_server_url at module scope
+    url_patches = (
+        [patch(t, cqf_url) for t in _CQFR4_TARGETS]
+        + [patch(t, fhir_url) for t in _FHIR_SERVER_TARGETS]
+        + [patch(t, fhir_auth) for t in _FHIR_AUTH_TARGETS]
+        + [patch(t, nlpaas_url) for t in _NLPAAS_TARGETS]
+        + [patch("src.util.git.clone_repo_to_temp_folder")]
+        + [patch("src.routers.forms_router.init_jobs_array")]
+    )
+
+    if db_conn and "REPLACE_ME" not in db_conn:
+        from sqlalchemy import create_engine as _ce
+
+        real_engine = _ce(db_conn)
+        logger.info(f"[INTEGRATION] DB: {db_conn.split('@')[-1]}")
+        url_patches += [
+            patch("src.util.databaseclient.db_engine", real_engine),
+            patch("src.services.jobstate.db_engine", real_engine),
+        ]
+    else:
+        logger.info("[INTEGRATION] DB: SQLite fallback (rcapi_test.sqlite)")
+
+    with contextlib.ExitStack() as stack:
+        for p in url_patches:
+            stack.enter_context(p)
+
+        from fastapi.testclient import TestClient
+
+        from main import app
+
+        with TestClient(app, raise_server_exceptions=True) as c:
+            yield c
+
+            # ── Teardown (TestClient + patches still active here) ────────────
+            # Delete the uploaded Questionnaire from CQF Ruler
+            if questionnaire_server_id:
+                logger.info(f"\n[INTEGRATION TEARDOWN] Deleting Questionnaire {questionnaire_server_id} from CQF Ruler...")
+                del_resp = _httpx.delete(f"{cqf_url}Questionnaire/{questionnaire_server_id}", timeout=15)
+                logger.info(f"\n[INTEGRATION TEARDOWN] Questionnaire delete response: {del_resp.status_code}")
+
+            # Delete batch jobs created during this test run via the (still-patched) TestClient
+            for batch_id in _batch_ids_to_cleanup:
+                logger.info(f"\n[INTEGRATION TEARDOWN] Deleting batch job {batch_id}...")
+                del_resp = c.delete(f"/smartchartui/batchjob/{batch_id}")
+                logger.info(f"\n[INTEGRATION TEARDOWN] Batch job {batch_id} delete response: {del_resp.status_code}")
+            _batch_ids_to_cleanup.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _assert_not_error_operation_outcome(body: dict, context: str) -> None:
+    """
+    Fail with a human-readable message if body is an error OperationOutcome. Helps pinpoint which external service returned an error.
+    """
+    if body.get("resourceType") == "OperationOutcome":
+        issues = body.get("issue", [])
+        severities = [i.get("severity", "unknown") for i in issues]
+        diagnostics = [i.get("diagnostics", i.get("details", {}).get("text", "no details")) for i in issues]
+        if any(s in ("error", "fatal") for s in severities):
+            pytest.fail(f"{context}: Received error OperationOutcome — severities={severities}, diagnostics={diagnostics}\nFull body: {body}")
+
+
+def _extract_batch_id(response_body: dict) -> str:
+    """
+    Extract the batchId from the Parameters response body returned by POST /smartchartui/batchjob.
+
+    The batchId lives at: parameter[?name=="batchId"].valueString
+    """
+    params = response_body.get("parameter", [])
+    for p in params:
+        if p.get("name") == "batchId":
+            batch_id = p.get("valueString")
+            if batch_id:
+                return batch_id
+    pytest.fail(f"Could not find batchId in POST /smartchartui/batchjob response.\nparameter list: {params}")
+
+
+def _get_status_observation(results_body: dict) -> dict | None:
+    """
+    Return the status observation entry from a results bundle, or None if not yet present.
+    """
+    for entry in results_body.get("entry", []):
+        if entry.get("fullUrl") == STATUS_OBS_FULL_URL:
+            return entry.get("resource", {})
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /forms/start — synchronous job runner
+# ---------------------------------------------------------------------------
+@pytest.mark.integration
+class TestStartJobsFullForm:
+    """
+    POST /forms/start (all jobs in a form, synchronous).
+
+    Input: start_jobs_requests[0] from user_data.json.
+    Asserts:
+      - HTTP 200
+      - Response is a Bundle (not an error OperationOutcome)
+      - Bundle has at least 1 entry (the Patient at minimum)
+    """
+
+    def test_start_jobs_full_form_returns_bundle(self, integration_client):
+        user_data = load_user_data()
+        scenarios = user_data.get("start_jobs_requests", [])
+        if not scenarios:
+            pytest.skip("No start_jobs_requests entries in user_data.json")
+
+        scenario = scenarios[0]
+        post_body = {k: v for k, v in scenario.items() if not k.startswith("_") and k != "expected_output"}
+
+        logger.info(
+            f"\n[INTEGRATION] POST /forms/start — jobPackage={post_body.get('parameter', [{}])[1].get('valueString', '?')}, patientId={post_body.get('parameter', [{}])[0].get('valueString', '?')}"
+        )
+        logger.info("\n[INTEGRATION] Calling CQF Ruler + external FHIR server (synchronous — may take 30-90s)...")
+
+        response = integration_client.post("/forms/start", json=post_body)
+
+        logger.info(f"\n[INTEGRATION] Response status: {response.status_code}")
+
+        assert response.status_code == 200, f"POST /forms/start returned {response.status_code}. Check that CQF Ruler ({post_body}) is accessible. Body: {response.text[:500]}"
+
+        body = response.json()
+        _assert_not_error_operation_outcome(body, "POST /forms/start (full form)")
+
+        assert body.get("resourceType") == "Bundle", f"Expected Bundle resourceType, got: {body.get('resourceType')}. Full body: {body}"
+
+        entries = body.get("entry", [])
+        logger.info(f"\n[INTEGRATION] Bundle returned {len(entries)} entries")
+        assert len(entries) >= 1, f"Expected at least 1 entry in results Bundle (the Patient resource at minimum), got {len(entries)}. This may indicate no CQL jobs ran or the patient was not found."
+
+        # Log a summary of resource types returned
+        resource_types = [e.get("resource", {}).get("resourceType", "unknown") for e in entries]
+        logger.info(f"\n[INTEGRATION] Resource types in bundle: {resource_types}")
+
+        # If expected_output was provided, validate resourceType matches
+        expected = scenario.get("expected_output", {})
+        if expected.get("resourceType"):
+            assert body["resourceType"] == expected["resourceType"], f"Expected resourceType {expected['resourceType']}, got {body['resourceType']}"
+
+
+@pytest.mark.integration
+class TestStartJobsSingleJob:
+    """
+    POST /forms/start with a specific job parameter (runs one CQL library, synchronous).
+
+    Input: start_jobs_requests[0] from user_data.json — the 'job' parameter already specifies a single CQL file (e.g. "ifu_information.cql").
+    Asserts:
+      - HTTP 200
+      - Response is a Bundle with at least 1 entry
+    """
+
+    def test_start_jobs_single_returns_bundle(self, integration_client):
+        user_data = load_user_data()
+        scenarios = user_data.get("start_jobs_requests", [])
+        if not scenarios:
+            pytest.skip("No start_jobs_requests entries in user_data.json")
+
+        # Find the scenario that has a specific 'job' parameter
+        scenario = next(
+            (s for s in scenarios if any(p.get("name") == "job" for p in s.get("parameter", []))),
+            scenarios[0],  # fall back to the first one
+        )
+        post_body = {k: v for k, v in scenario.items() if not k.startswith("_") and k != "expected_output"}
+
+        job_param = next((p for p in post_body.get("parameter", []) if p.get("name") == "job"), None)
+        logger.info(f"\n[INTEGRATION] POST /forms/start — single job: {job_param.get('valueString') if job_param else 'all (no job param)'}")
+        logger.info("\n[INTEGRATION] Calling CQF Ruler + external FHIR server (synchronous)...")
+
+        response = integration_client.post("/forms/start", json=post_body)
+
+        logger.info(f"\n[INTEGRATION] Response status: {response.status_code}")
+
+        assert response.status_code == 200, f"POST /forms/start (single job) returned {response.status_code}. Check CQF Ruler connectivity and that the library exists. Body: {response.text[:500]}"
+
+        body = response.json()
+        _assert_not_error_operation_outcome(body, "POST /forms/start (single job)")
+
+        assert body.get("resourceType") == "Bundle", f"Expected Bundle, got {body.get('resourceType')}. Full: {body}"
+
+        entries = body.get("entry", [])
+        logger.info(f"\n[INTEGRATION] Bundle returned {len(entries)} entries")
+        assert len(entries) >= 1, f"Expected at least 1 entry (Patient + result), got {len(entries)}. Check that the CQL library runs correctly against the patient."
+
+        resource_types = [e.get("resource", {}).get("resourceType", "?") for e in entries]
+        logger.info(f"\n[INTEGRATION] Resource types: {resource_types}")
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /smartchartui/batchjob → poll GET /smartchartui/results/{id}
+# ---------------------------------------------------------------------------
+@pytest.mark.integration
+class TestBatchJobPolling:
+    """
+    POST /smartchartui/batchjob (async), then poll GET /smartchartui/results/{batchId} until the status-observation shows "complete".
+
+    Input: batch_jobs_requests[0] from user_data.json.
+    Asserts:
+      - POST returns 200 with a Parameters body containing a batchId
+      - Within 5 minutes, GET /smartchartui/results/{batchId} returns a Bundle where Observation/status-observation has status == "complete"
+      - The final results bundle has at least BATCH_JOB_MIN_RESULT_ENTRIES entries
+    """
+
+    def test_batch_job_completes_within_timeout(self, integration_client):
+        user_data = load_user_data()
+        scenarios = user_data.get("batch_jobs_requests", [])
+        if not scenarios:
+            pytest.skip("No batch_jobs_requests entries in user_data.json")
+
+        post_body = {k: v for k, v in scenarios[0].items() if not k.startswith("_")}
+
+        # ── Step 1: POST the batch job ──────────────────────────────────────
+        logger.info(
+            f"\n[INTEGRATION] POST /smartchartui/batchjob — jobPackage={next((p.get('valueString') for p in post_body.get('parameter', []) if p.get('name') == 'jobPackage'), '?')}, "
+            f"patientId={next((p.get('valueString') for p in post_body.get('parameter', []) if p.get('name') == 'patientId'), '?')}"
+        )
+
+        post_response = integration_client.post("/smartchartui/batchjob", json=post_body)
+        logger.info(f"\n[INTEGRATION] POST response status: {post_response.status_code}")
+
+        assert post_response.status_code == 200, (
+            f"POST /smartchartui/batchjob returned {post_response.status_code}. Check that the Questionnaire exists on CQF Ruler and the DB is accessible. Body: {post_response.text[:500]}"
+        )
+
+        post_body_response = post_response.json()
+        _assert_not_error_operation_outcome(post_body_response, "POST /smartchartui/batchjob")
+
+        batch_id = _extract_batch_id(post_body_response)
+        # Register for teardown cleanup (see _upload_integration_questionnaire fixture)
+        _batch_ids_to_cleanup.append(batch_id)
+        logger.info("\n[INTEGRATION] " + f"Batch job started — batchId: {batch_id}")
+        logger.info(
+            f"\n[INTEGRATION] Will poll GET /smartchartui/results/{batch_id} every {BATCH_JOB_POLL_INTERVAL_SECONDS}s for up to {BATCH_JOB_POLL_TIMEOUT_SECONDS}s ({BATCH_JOB_POLL_TIMEOUT_SECONDS // 60} min)..."
+        )
+
+        # ── Step 2: Poll until complete ─────────────────────────────────────
+        max_attempts = BATCH_JOB_POLL_TIMEOUT_SECONDS // BATCH_JOB_POLL_INTERVAL_SECONDS
+        results_url = f"/smartchartui/results/{batch_id}"
+        final_body = None
+
+        for attempt in range(1, max_attempts + 1):
+            time.sleep(BATCH_JOB_POLL_INTERVAL_SECONDS)
+
+            poll_response = integration_client.get(results_url)
+
+            if poll_response.status_code != 200:
+                logger.info(f"\n[INTEGRATION]    Attempt {attempt}/{max_attempts}: GET {results_url} → {poll_response.status_code} (retrying...)")
+                if poll_response.status_code >= 500:
+                    logger.error(f"500 Error Body: {poll_response.text}")
+                continue
+
+            poll_body = poll_response.json()
+            status_obs = _get_status_observation(poll_body)
+
+            if status_obs is None:
+                logger.info(f"\n[INTEGRATION]   Attempt {attempt}/{max_attempts}: no status-observation yet in bundle ({len(poll_body.get('entry', []))} entries total)")
+                continue
+
+            obs_status = status_obs.get("status", "unknown")
+            status_text = status_obs.get("valueCodeableConcept", {}).get("text", "no text")
+            entry_count = len(poll_body.get("entry", []))
+
+            logger.info(f"\n[INTEGRATION]   Attempt {attempt}/{max_attempts}: status={obs_status}, progress='{status_text}', entries={entry_count}")
+
+            if obs_status == STATUS_OBS_COMPLETE_CODE:
+                logger.info(f"\n[INTEGRATION] Batch job COMPLETE after {attempt * BATCH_JOB_POLL_INTERVAL_SECONDS}s — {entry_count} entries in results bundle")
+                final_body = poll_body
+                break
+
+        # ── Step 3: Assert completion ───────────────────────────────────────
+        assert final_body is not None, (
+            f"Batch job {batch_id} did not complete within {BATCH_JOB_POLL_TIMEOUT_SECONDS}s ({BATCH_JOB_POLL_TIMEOUT_SECONDS // 60} min). This may indicate a hung CQL execution, an unreachable external "
+            f"FHIR server, or an NLPaaS timeout. Check the API server logs for job {batch_id}."
+        )
+
+        final_entries = final_body.get("entry", [])
+        logger.info("\n[INTEGRATION] " + f"Final results bundle: {len(final_entries)} entries total")
+
+        assert len(final_entries) >= BATCH_JOB_MIN_RESULT_ENTRIES, (
+            f"Expected at least {BATCH_JOB_MIN_RESULT_ENTRIES} entries in the completed results bundle, got {len(final_entries)}. The jobs may have run but produced fewer results than expected. "
+            "Check CQL library outputs and patient data for jobPackage referenced in user_data.json."
+        )
+
+        # Log a breakdown of what came back
+        resource_types: dict[str, int] = {}
+        for entry in final_entries:
+            rt = entry.get("resource", {}).get("resourceType", "unknown")
+            resource_types[rt] = resource_types.get(rt, 0) + 1
+        logger.info(f"\n[INTEGRATION] Resource type breakdown: {resource_types}")

--- a/tests/test_main_router.py
+++ b/tests/test_main_router.py
@@ -1,0 +1,70 @@
+"""
+Tests for main_router.py
+Endpoints covered:
+  GET /
+  GET /health
+  GET /config
+"""
+
+
+class TestRootEndpoint:
+    def test_root_returns_operation_outcome(self, client):
+        """GET / should return a FHIR OperationOutcome with 'processing' code."""
+        response = client.get("/")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "processing"
+
+    def test_root_message_content(self, client):
+        """GET / diagnostic message should reference the root URL."""
+        response = client.get("/")
+        body = response.json()
+        assert "base URL" in body["issue"][0]["diagnostics"].lower() or "root" in body["issue"][0]["diagnostics"].lower()
+
+
+class TestHealthEndpoint:
+    def test_health_returns_200(self, client, monkeypatch):
+        """GET /health should return 200 with a dict response."""
+        monkeypatch.setattr(
+            "src.routers.main_router.get_health_of_stack",
+            lambda: {"status": "ok", "services": {}},
+        )
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert isinstance(response.json(), dict)
+
+    def test_health_response_has_expected_shape(self, client, monkeypatch):
+        """GET /health response dict should represent service health."""
+        mock_health = {"status": "ok", "CQF_RULER_R4": "reachable"}
+        monkeypatch.setattr("src.routers.main_router.get_health_of_stack", lambda: mock_health)
+        response = client.get("/health")
+        body = response.json()
+        assert "status" in body or len(body) > 0  # Some health shape returned
+
+
+class TestConfigEndpoint:
+    def test_config_empty_when_no_primary_identifier(self, client, monkeypatch):
+        """GET /config returns empty dict when PRIMARYIDENTIFIER_SYSTEM is not set."""
+        monkeypatch.setattr("src.routers.main_router.config_endpoint", {})
+        response = client.get("/config")
+        assert response.status_code == 200
+        assert response.json() == {}
+
+    def test_config_populated_with_primary_identifier(self, client, monkeypatch):
+        """GET /config returns ConfigEndpointModel when primary identifier is configured."""
+        from src.util.settings import ConfigEndpointModel, ConfigEndpointPrimaryIdentifier
+
+        expected = ConfigEndpointModel(
+            primaryIdentifier=ConfigEndpointPrimaryIdentifier(
+                system="http://example.org/pid",
+                label="MRN",
+            )
+        )
+        monkeypatch.setattr("src.routers.main_router.config_endpoint", expected)
+        response = client.get("/config")
+        assert response.status_code == 200
+        body = response.json()
+        assert "primaryIdentifier" in body
+        assert body["primaryIdentifier"]["system"] == "http://example.org/pid"
+        assert body["primaryIdentifier"]["label"] == "MRN"

--- a/tests/test_nlpql_router.py
+++ b/tests/test_nlpql_router.py
@@ -1,0 +1,206 @@
+"""
+Tests for nlpql_router.py
+Endpoints covered:
+  GET  /forms/nlpql
+  GET  /forms/nlpql/{library_name}
+  POST /forms/nlpql
+  PUT  /forms/nlpql/{library_name}
+
+Route Ordering Note
+-------------------
+nlpql_router is now registered BEFORE forms_router in main.py (user fix).
+This means GET /forms/nlpql now correctly routes to get_nlpql_libraries().
+
+NLPAAS_URL Note
+---------------
+In production, NLPAAS_URL env var is the string "False" when NLPaaS isn't
+configured. settings.py appends "/" making it "False/". create_nlpql() checks
+`if not nlpaas_url:` — "False/" is truthy, so only a truly empty/falsy value
+triggers the guard. Tests that want to simulate "no NLPaaS" directly patch
+`src.services.libraryhandler.nlpaas_url` to "" (empty string, falsy).
+"""
+
+import base64
+from unittest.mock import patch
+
+from tests.conftest import load_fixture, make_fhir_searchset, make_response
+
+# ---------------------------------------------------------------------------
+# Valid NLPQL that the phenotype library name parser can extract metadata from
+# ---------------------------------------------------------------------------
+VALID_NLPQL = "\n".join(
+    [
+        "// Phenotype library TestNLPQLLibrary;",
+        'phenotype "TestNLPQLLibrary" version "1.0.0";',
+        'documentset myDocs: Clarity.createReportTagList(["Radiology"]);',
+    ]
+)
+
+
+# ===========================================================================
+# GET /forms/nlpql  — list all NLPQL libraries
+# ===========================================================================
+class TestGetNlpqlLibraries:
+    def test_get_nlpql_libraries_success(self, client, mock_httpx):
+        """GET /forms/nlpql → Bundle of NLPQL libraries from CQF Ruler."""
+        nlpql_lib = load_fixture("fhir_library_nlpql")
+        bundle = make_fhir_searchset([nlpql_lib])
+        mock_httpx.get.return_value = make_response(200, bundle)
+
+        response = client.get("/forms/nlpql")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Bundle"
+        assert body["total"] == 1
+
+    def test_get_nlpql_libraries_empty(self, client, mock_httpx):
+        """GET /forms/nlpql → Bundle with total=0 when no NLPQL libraries exist."""
+        empty = load_fixture("fhir_bundle_empty")
+        mock_httpx.get.return_value = make_response(200, empty)
+
+        response = client.get("/forms/nlpql")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Bundle"
+        assert body["total"] == 0
+
+    def test_get_nlpql_libraries_server_error(self, client, mock_httpx):
+        """GET /forms/nlpql → OperationOutcome when CQF Ruler returns non-200."""
+        mock_httpx.get.return_value = make_response(503, {})
+
+        response = client.get("/forms/nlpql")
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+
+# ===========================================================================
+# GET /forms/nlpql/{library_name}
+# ===========================================================================
+class TestGetNlpqlByName:
+    def test_get_nlpql_by_name_returns_decoded_text(self, client, mock_httpx):
+        """GET /forms/nlpql/{name} → plain text NLPQL content when found."""
+        nlpql_lib = load_fixture("fhir_library_nlpql")
+        bundle = make_fhir_searchset([nlpql_lib])
+        mock_httpx.get.return_value = make_response(200, bundle)
+
+        response = client.get("/forms/nlpql/TestNLPQLLibrary")
+        expected = base64.b64decode(nlpql_lib["content"][0]["data"]).decode("utf-8")
+        assert expected in response.text or response.json() == expected
+
+    def test_get_nlpql_by_name_not_found(self, client, mock_httpx):
+        """GET /forms/nlpql/{name} → OperationOutcome not-found when no match."""
+        empty = load_fixture("fhir_bundle_empty")
+        mock_httpx.get.return_value = make_response(200, empty)
+
+        response = client.get("/forms/nlpql/NonExistentLibrary")
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "not-found"
+
+    def test_get_nlpql_server_error(self, client, mock_httpx):
+        """GET /forms/nlpql/{name} → OperationOutcome on server error."""
+        mock_httpx.get.return_value = make_response(503, {})
+
+        response = client.get("/forms/nlpql/TestLibrary")
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+
+# ===========================================================================
+# POST /forms/nlpql
+# ===========================================================================
+class TestSaveNlpql:
+    def test_save_nlpql_no_nlpaas_configured(self, client, mock_httpx):
+        """POST /forms/nlpql → 400 OperationOutcome when NLPAAS_URL is not configured.
+
+        Patches nlpaas_url to "" (empty/falsy) to trigger the guard in create_nlpql.
+        The default env NLPAAS_URL resolves to "False/" (truthy) in settings.py,
+        so we must patch the module-level variable directly.
+        """
+        with patch("src.services.libraryhandler.nlpaas_url", ""):
+            response = client.post("/forms/nlpql", content=VALID_NLPQL, headers={"Content-Type": "text/plain"})
+        assert response.status_code == 400
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "invalid"
+
+    def test_save_nlpql_success(self, client, mock_httpx):
+        """POST /forms/nlpql → 201 OperationOutcome when NLPaaS validates and CQF Ruler accepts."""
+        empty = load_fixture("fhir_bundle_empty")
+        mock_httpx.get.return_value = make_response(200, empty)
+        mock_httpx.post.return_value = make_response(201, {"id": "new-nlpql-001"})
+
+        with (
+            patch("src.services.libraryhandler.nlpaas_url", "http://nlpaas.example.org/"),
+            patch("src.services.libraryhandler.validate_nlpql", return_value=True),
+        ):
+            response = client.post("/forms/nlpql", content=VALID_NLPQL, headers={"Content-Type": "text/plain"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["severity"] == "information"
+
+    def test_save_nlpql_empty_body_rejected(self, client):
+        """POST /forms/nlpql with empty body → 400 OperationOutcome (custom validation handler)."""
+        response = client.post("/forms/nlpql", content="", headers={"Content-Type": "text/plain"})
+        assert response.status_code == 400
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+    def test_save_nlpql_updates_existing_library(self, client, mock_httpx):
+        """POST /forms/nlpql → 201 when library already exists (triggers PUT on CQF Ruler)."""
+        nlpql_lib = load_fixture("fhir_library_nlpql")
+        existing_bundle = make_fhir_searchset([nlpql_lib])
+        mock_httpx.get.return_value = make_response(200, existing_bundle)
+        mock_httpx.put.return_value = make_response(200, {"id": "test-nlpql-library-001"})
+
+        with (
+            patch("src.services.libraryhandler.nlpaas_url", "http://nlpaas.example.org/"),
+            patch("src.services.libraryhandler.validate_nlpql", return_value=True),
+        ):
+            response = client.post("/forms/nlpql", content=VALID_NLPQL, headers={"Content-Type": "text/plain"})
+        assert response.status_code == 201
+
+    def test_save_nlpql_validation_fails(self, client, mock_httpx):
+        """POST /forms/nlpql → 400 OperationOutcome when NLPQL validation fails."""
+        error_oo = {
+            "resourceType": "OperationOutcome",
+            "issue": [{"severity": "error", "code": "invalid", "diagnostics": "Parse error"}],
+        }
+        with (
+            patch("src.services.libraryhandler.nlpaas_url", "http://nlpaas.example.org/"),
+            patch("src.services.libraryhandler.validate_nlpql", return_value=error_oo),
+        ):
+            response = client.post("/forms/nlpql", content=VALID_NLPQL, headers={"Content-Type": "text/plain"})
+        assert response.status_code == 400
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+
+# ===========================================================================
+# PUT /forms/nlpql/{library_name}
+# ===========================================================================
+class TestUpdateNlpql:
+    def test_update_nlpql_success(self, client, mock_httpx):
+        """PUT /forms/nlpql/{name} → 201 OperationOutcome on successful update."""
+        nlpql_lib = load_fixture("fhir_library_nlpql")
+        existing_bundle = make_fhir_searchset([nlpql_lib])
+        mock_httpx.get.return_value = make_response(200, existing_bundle)
+        mock_httpx.put.return_value = make_response(200, {"id": "test-nlpql-library-001"})
+
+        with (
+            patch("src.services.libraryhandler.nlpaas_url", "http://nlpaas.example.org/"),
+            patch("src.services.libraryhandler.validate_nlpql", return_value=True),
+        ):
+            response = client.put("/forms/nlpql/TestNLPQLLibrary", content=VALID_NLPQL, headers={"Content-Type": "text/plain"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["severity"] == "information"
+
+    def test_update_nlpql_empty_body_rejected(self, client):
+        """PUT /forms/nlpql/{name} with empty body → 400 (custom validation handler)."""
+        response = client.put("/forms/nlpql/TestNLPQLLibrary", content="", headers={"Content-Type": "text/plain"})
+        assert response.status_code == 400
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"

--- a/tests/test_smartchartui_router.py
+++ b/tests/test_smartchartui_router.py
@@ -1,0 +1,454 @@
+"""
+Tests for smartchartui.py
+Endpoints covered:
+  GET    /smartchartui/Patient/{patient_id}
+  GET    /smartchartui/Patient
+  GET    /smartchartui/group
+  GET    /smartchartui/questionnaire
+  GET    /smartchartui/job/{id}
+  GET    /smartchartui/batchjob
+  GET    /smartchartui/batchjob/{id}
+  DELETE /smartchartui/batchjob/{id}
+  POST   /smartchartui/batchjob
+  GET    /smartchartui/results/{id}
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import load_fixture, load_user_data, make_fhir_searchset, make_response
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build realistic job / batchjob dicts for DB mocks
+# ---------------------------------------------------------------------------
+def _make_job_dict(job_id: str, status: str = "complete") -> dict:
+    """Build a minimal ParametersJob dict as it would be stored in the DB."""
+    return {
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "jobId", "valueString": job_id},
+            {"name": "jobStartDateTime", "valueDateTime": "2024-01-01T00:00:00Z"},
+            {"name": "jobStatus", "valueString": status},
+            {"name": "result", "resource": {"resourceType": "Bundle", "type": "collection", "entry": []}},
+            {"name": "jobCompletedDateTime", "valueDateTime": "2024-01-01T00:05:00Z"},
+        ],
+    }
+
+
+def _make_batch_job_dict(batch_id: str, child_ids: list[str]) -> dict:
+    """Build a minimal BatchParametersJob dict as stored in the DB."""
+    entries = [{"item": {"display": cid}} for cid in child_ids]
+    return {
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "batchId", "valueString": batch_id},
+            {"name": "jobStartDateTime", "valueDateTime": "2024-01-01T00:00:00Z"},
+            {"name": "patientId", "valueString": "test-patient-001"},
+            {"name": "jobPackage", "valueString": "TestQuestionnaire"},
+            {
+                "name": "childJobs",
+                "resource": {"resourceType": "List", "status": "current", "mode": "working", "entry": entries},
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST body for creating a batch job
+# ---------------------------------------------------------------------------
+BATCH_JOB_BODY = {
+    "resourceType": "Parameters",
+    "parameter": [
+        {"name": "patientId", "valueString": "test-patient-001"},
+        {"name": "jobPackage", "valueString": "TestQuestionnaire"},
+    ],
+}
+
+
+# ===========================================================================
+# Patient endpoints
+# ===========================================================================
+class TestReadPatient:
+    def test_read_patient_success(self, client, mock_fhir_clients):
+        """GET /smartchartui/Patient/{id} → Patient resource JSON."""
+        ext_client, _ = mock_fhir_clients
+        patient = load_fixture("fhir_patient")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = patient
+        ext_client.readResource.return_value = mock_resp
+
+        response = client.get(f"/smartchartui/Patient/{patient['id']}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Patient"
+        assert body["id"] == patient["id"]
+
+    def test_read_patient_extracts_resource_type_from_response(self, client, mock_fhir_clients):
+        """GET /smartchartui/Patient/{id} → response contains Patient resource type."""
+        ext_client, _ = mock_fhir_clients
+        patient = load_fixture("fhir_patient")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = patient
+        ext_client.readResource.return_value = mock_resp
+
+        response = client.get(f"/smartchartui/Patient/{patient['id']}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Patient"
+
+
+class TestSearchPatient:
+    def test_search_patient_no_params_returns_all(self, client, mock_fhir_clients):
+        """GET /smartchartui/Patient → searches all patients when no params given."""
+        ext_client, _ = mock_fhir_clients
+        patient = load_fixture("fhir_patient")
+        bundle = make_fhir_searchset([patient])
+        ext_client.searchResource.return_value = bundle
+
+        response = client.get("/smartchartui/Patient")
+        assert response.status_code == 200
+        ext_client.searchResource.assert_called_once_with("Patient")
+
+    def test_search_patient_by_id(self, client, mock_fhir_clients):
+        """GET /smartchartui/Patient?_id=xxx → searches by _id parameter."""
+        ext_client, _ = mock_fhir_clients
+        patient = load_fixture("fhir_patient")
+        bundle = make_fhir_searchset([patient])
+        ext_client.searchResource.return_value = bundle
+
+        response = client.get("/smartchartui/Patient?_id=test-patient-001")
+        assert response.status_code == 200
+        call_args = ext_client.searchResource.call_args
+        assert call_args[1]["parameters"] == {"_id": "test-patient-001"}
+
+    def test_search_patient_by_name(self, client, mock_fhir_clients):
+        """GET /smartchartui/Patient?name=John → searches by name."""
+        ext_client, _ = mock_fhir_clients
+        patient = load_fixture("fhir_patient")
+        bundle = make_fhir_searchset([patient])
+        ext_client.searchResource.return_value = bundle
+
+        response = client.get("/smartchartui/Patient?name=John")
+        assert response.status_code == 200
+        call_args = ext_client.searchResource.call_args
+        assert "name" in call_args[1]["parameters"]
+
+    def test_search_patient_by_identifier(self, client, mock_fhir_clients):
+        """GET /smartchartui/Patient?identifier=MRN-001 → searches by identifier."""
+        ext_client, _ = mock_fhir_clients
+        patient = load_fixture("fhir_patient")
+        bundle = make_fhir_searchset([patient])
+        ext_client.searchResource.return_value = bundle
+
+        response = client.get("/smartchartui/Patient?identifier=MRN-001")
+        assert response.status_code == 200
+        call_args = ext_client.searchResource.call_args
+        assert call_args[1]["parameters"] == {"identifier": "MRN-001"}
+
+    def test_search_patient_by_name_and_birthdate(self, client, mock_fhir_clients):
+        """GET /smartchartui/Patient?name=John&birthdate=1990-01-15 → searches both params."""
+        ext_client, _ = mock_fhir_clients
+        bundle = make_fhir_searchset([])
+        ext_client.searchResource.return_value = bundle
+
+        response = client.get("/smartchartui/Patient?name=John&birthdate=1990-01-15")
+        assert response.status_code == 200
+        call_args = ext_client.searchResource.call_args
+        assert "name" in call_args[1]["parameters"]
+        assert "birthdate" in call_args[1]["parameters"]
+
+
+# ===========================================================================
+# Group endpoint
+# ===========================================================================
+class TestSearchGroup:
+    def test_search_group_returns_list(self, client, mock_fhir_clients, mock_httpx):
+        """GET /smartchartui/group → list containing Group and Patient resources."""
+        _, internal_client = mock_fhir_clients
+        patient = load_fixture("fhir_patient")
+
+        group = {
+            "resourceType": "Group",
+            "id": "test-group-001",
+            "type": "person",
+            "actual": True,
+            "member": [{"entity": {"reference": "http://localhost:9090/fhir/Patient/test-patient-001"}}],
+        }
+        internal_client.searchResource.return_value = [group]
+
+        mock_patient_resp = MagicMock()
+        mock_patient_resp.json.return_value = patient
+        mock_httpx.get.return_value = mock_patient_resp
+
+        response = client.get("/smartchartui/group")
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body, list)
+        # Should contain the Group + the Patient from the member reference
+        resource_types = [item.get("resourceType") for item in body]
+        assert "Group" in resource_types
+
+    def test_search_group_empty(self, client, mock_fhir_clients):
+        """GET /smartchartui/group → empty list when no groups exist."""
+        _, internal_client = mock_fhir_clients
+        internal_client.searchResource.return_value = []
+
+        response = client.get("/smartchartui/group")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+# ===========================================================================
+# Questionnaire endpoint
+# ===========================================================================
+class TestSearchQuestionnaire:
+    def test_search_questionnaire_returns_list(self, client, mock_fhir_clients):
+        """GET /smartchartui/questionnaire → list of Questionnaires."""
+        _, internal_client = mock_fhir_clients
+        questionnaire = load_fixture("fhir_questionnaire")
+        internal_client.searchResource.return_value = [questionnaire]
+
+        response = client.get("/smartchartui/questionnaire")
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body, list)
+        assert body[0]["resourceType"] == "Questionnaire"
+
+    def test_search_questionnaire_empty(self, client, mock_fhir_clients):
+        """GET /smartchartui/questionnaire → empty list when no questionnaires."""
+        _, internal_client = mock_fhir_clients
+        internal_client.searchResource.return_value = []
+
+        response = client.get("/smartchartui/questionnaire")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+# ===========================================================================
+# Job (child job) endpoint
+# ===========================================================================
+class TestGetJob:
+    def test_get_job_not_found(self, client, mock_jobstate):
+        """GET /smartchartui/job/{id} → 404 OperationOutcome when job not in DB."""
+        mock_jobstate["get_job"].return_value = None
+
+        response = client.get("/smartchartui/job/nonexistent-job-id")
+        assert response.status_code == 404
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+        assert body["issue"][0]["code"] == "not-found"
+
+    def test_get_job_found(self, client, mock_jobstate):
+        """GET /smartchartui/job/{id} → returns job dict when found in DB."""
+        job_id = str(uuid.uuid4())
+        job = _make_job_dict(job_id)
+        mock_jobstate["get_job"].return_value = job
+
+        response = client.get(f"/smartchartui/job/{job_id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Parameters"
+
+
+# ===========================================================================
+# Batch job GET endpoints
+# ===========================================================================
+class TestGetAllBatchJobs:
+    def test_get_all_batch_jobs_empty(self, client, mock_jobstate):
+        """GET /smartchartui/batchjob → empty list when no batch jobs in DB."""
+        mock_jobstate["get_all_batch_jobs"].return_value = []
+
+        response = client.get("/smartchartui/batchjob")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_get_all_batch_jobs_includes_status(self, client, mock_jobstate):
+        """GET /smartchartui/batchjob → batch job dicts include batchJobStatus."""
+        batch_id = str(uuid.uuid4())
+        child_id = str(uuid.uuid4())
+        batch_job = _make_batch_job_dict(batch_id, [child_id])
+
+        mock_jobstate["get_all_batch_jobs"].return_value = [batch_job]
+        mock_jobstate["get_child_job_statuses"].return_value = {child_id: "complete"}
+
+        response = client.get("/smartchartui/batchjob")
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body, list)
+        assert len(body) == 1
+        param_names = [p["name"] for p in body[0]["parameter"]]
+        assert "batchJobStatus" in param_names
+
+
+class TestGetBatchJobById:
+    def test_get_batch_job_not_found(self, client, mock_jobstate):
+        """GET /smartchartui/batchjob/{id} → 404 when batch job not in DB."""
+        mock_jobstate["get_batch_job"].return_value = None
+
+        response = client.get("/smartchartui/batchjob/nonexistent-id")
+        assert response.status_code == 404
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+    def test_get_batch_job_found(self, client, mock_jobstate):
+        """GET /smartchartui/batchjob/{id} → returns batch job dict when found."""
+        batch_id = str(uuid.uuid4())
+        batch_job = _make_batch_job_dict(batch_id, [])
+        mock_jobstate["get_batch_job"].return_value = batch_job
+
+        response = client.get(f"/smartchartui/batchjob/{batch_id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Parameters"
+
+
+# ===========================================================================
+# Delete batch job
+# ===========================================================================
+class TestDeleteBatchJob:
+    def test_delete_batch_job_success(self, client, mock_jobstate):
+        """DELETE /smartchartui/batchjob/{id} → OperationOutcome deleted success."""
+        from fastapi.responses import JSONResponse
+
+        from src.services.errorhandler import make_operation_outcome
+
+        batch_id = str(uuid.uuid4())
+        oo = make_operation_outcome("deleted", f"Batch Job ID {batch_id} has been successfully deleted from the database", "information")
+        mock_jobstate["delete_batch_job"].return_value = JSONResponse(oo)
+
+        response = client.delete(f"/smartchartui/batchjob/{batch_id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+    def test_delete_batch_job_not_found(self, client, mock_jobstate):
+        """DELETE /smartchartui/batchjob/{id} → 404 when batch job not in DB."""
+        from fastapi.responses import JSONResponse
+
+        from src.services.errorhandler import make_operation_outcome
+
+        batch_id = "nonexistent"
+        oo = make_operation_outcome("not-found", f"Batch Job ID {batch_id} was not found in the database")
+        mock_jobstate["delete_batch_job"].return_value = JSONResponse(oo, status_code=404)
+
+        response = client.delete(f"/smartchartui/batchjob/{batch_id}")
+        assert response.status_code == 404
+
+
+# ===========================================================================
+# POST batch job
+# ===========================================================================
+class TestPostBatchJob:
+    def test_post_batch_job_creates_job(self, client, mock_fhir_clients, mock_jobstate, mock_httpx):
+        """POST /smartchartui/batchjob → creates batch job and returns it with Location header."""
+        questionnaire = load_fixture("fhir_questionnaire")
+
+        # Use unittest.mock.patch (thread-safe across anyio threadpool boundary)
+        with patch("src.routers.smartchartui.get_form", return_value=questionnaire):
+            # add_to_batch_jobs succeeds
+            mock_jobstate["add_to_batch_jobs"].return_value = True
+            response = client.post("/smartchartui/batchjob", json=BATCH_JOB_BODY)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Parameters"
+        assert "Location" in response.headers
+
+    def test_post_batch_job_db_failure_returns_500(self, client, mock_fhir_clients, mock_jobstate, mock_httpx):
+        """POST /smartchartui/batchjob → 500 OperationOutcome when DB insert fails."""
+        questionnaire = load_fixture("fhir_questionnaire")
+
+        with patch("src.routers.smartchartui.get_form", return_value=questionnaire):
+            mock_jobstate["add_to_batch_jobs"].return_value = False
+            response = client.post("/smartchartui/batchjob", json=BATCH_JOB_BODY)
+
+        assert response.status_code == 500
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+
+# ===========================================================================
+# Results endpoint
+# ===========================================================================
+class TestGetBatchJobResults:
+    def test_get_results_not_found(self, client, mock_jobstate):
+        """GET /smartchartui/results/{id} → 404 when batch job not in DB."""
+        mock_jobstate["get_batch_job"].return_value = None
+
+        response = client.get("/smartchartui/results/nonexistent-id")
+        assert response.status_code == 404
+        body = response.json()
+        assert body["resourceType"] == "OperationOutcome"
+
+    def test_get_results_with_complete_jobs(self, client, mock_jobstate, mock_fhir_clients, mock_httpx):
+        """GET /smartchartui/results/{id} → Bundle with status observation when all jobs complete."""
+        _, ext_client = mock_fhir_clients
+        batch_id = str(uuid.uuid4())
+        child_id = str(uuid.uuid4())
+        patient = load_fixture("fhir_patient")
+
+        batch_job = _make_batch_job_dict(batch_id, [child_id])
+        child_job = _make_job_dict(child_id, status="complete")
+
+        mock_jobstate["get_batch_job"].return_value = batch_job
+        mock_jobstate["get_job"].return_value = child_job
+
+        # external_fhir_client.readResource for the Patient
+        mock_patient_response = MagicMock()
+        mock_patient_response.json.return_value = patient
+        ext_client = mock_fhir_clients[0]
+        ext_client.readResource.return_value = mock_patient_response
+
+        response = client.get(f"/smartchartui/results/{batch_id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Bundle"
+
+
+# ===========================================================================
+# Data-driven tests using user_data.json
+# ===========================================================================
+class TestBatchJobUserData:
+    @pytest.mark.parametrize("scenario", load_user_data().get("batch_jobs_requests", []))
+    def test_batch_job_with_real_data(self, client, mock_fhir_clients, mock_jobstate, mock_httpx, scenario):
+        """POST /smartchartui/batchjob with user-provided patient and job package data."""
+        patient_param = next((p for p in scenario["parameter"] if p["name"] == "patientId"), None)
+        if not patient_param or patient_param["valueString"] == "REPLACE_ME":
+            pytest.skip("User data not yet populated in tests/fixtures/user_data.json")
+
+        questionnaire = load_fixture("fhir_questionnaire")
+        bundle = make_fhir_searchset([questionnaire])
+        mock_httpx.get.return_value = make_response(200, bundle)
+        mock_jobstate["add_to_batch_jobs"].return_value = True
+
+        response = client.post("/smartchartui/batchjob", json=scenario)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == "Parameters"
+        param_names = [p["name"] for p in body["parameter"]]
+        assert "batchId" in param_names
+
+
+class TestPatientSearchUserData:
+    @pytest.mark.parametrize("patient", load_user_data().get("patients", []))
+    def test_read_patient_with_real_id(self, client, mock_fhir_clients, patient):
+        """GET /smartchartui/Patient/{id} with user-provided patient ID."""
+        if patient["id"] == "REPLACE_ME":
+            pytest.skip("User data not yet populated in tests/fixtures/user_data.json")
+
+        ext_client, _ = mock_fhir_clients
+        patient_fixture = load_fixture("fhir_patient")
+        patient_fixture["id"] = patient["id"]
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = patient_fixture
+        ext_client.readResource.return_value = mock_resp
+
+        response = client.get(f"/smartchartui/Patient/{patient['id']}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resourceType"] == patient.get("expected_resource_type", "Patient")
+        assert body["id"] == patient["id"]

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,65 @@
+"""
+Tests for webhook.py
+Endpoint covered:
+  POST /webhook
+"""
+
+GITHUB_WEBHOOK_PAYLOAD = {
+    "ref": "refs/heads/main",
+    "repository": {
+        "id": 123456,
+        "name": "knowledgebase",
+        "full_name": "org/knowledgebase",
+        "clone_url": "https://github.com/org/knowledgebase.git",
+        "ssh_url": "git@github.com:org/knowledgebase.git",
+    },
+}
+
+
+class TestWebhook:
+    def test_webhook_returns_acknowledged(self, client, monkeypatch):
+        """POST /webhook → returns 'Acknowledged' string on success."""
+        monkeypatch.setattr(
+            "src.routers.webhook.clone_repo_to_temp_folder",
+            lambda url: None,  # No-op: don't actually clone
+        )
+        response = client.post("/webhook", json=GITHUB_WEBHOOK_PAYLOAD)
+        assert response.status_code == 200
+        assert response.json() == "Acknowledged"
+
+    def test_webhook_calls_clone_with_ssh_url(self, client, monkeypatch):
+        """POST /webhook → clone_repo_to_temp_folder is called with the ssh_url."""
+        captured_url = []
+
+        def mock_clone(url):
+            captured_url.append(url)
+
+        monkeypatch.setattr("src.routers.webhook.clone_repo_to_temp_folder", mock_clone)
+
+        client.post("/webhook", json=GITHUB_WEBHOOK_PAYLOAD)
+        assert len(captured_url) == 1
+        assert captured_url[0] == GITHUB_WEBHOOK_PAYLOAD["repository"]["ssh_url"]
+
+    def test_webhook_uses_ssh_not_clone_url(self, client, monkeypatch):
+        """POST /webhook → SSH URL (not HTTPS clone_url) is passed to clone function."""
+        captured_url = []
+
+        def mock_clone(url):
+            captured_url.append(url)
+
+        monkeypatch.setattr("src.routers.webhook.clone_repo_to_temp_folder", mock_clone)
+        client.post("/webhook", json=GITHUB_WEBHOOK_PAYLOAD)
+
+        assert captured_url[0] == "git@github.com:org/knowledgebase.git"
+        assert "https://" not in captured_url[0]
+
+    def test_webhook_missing_repository_key_raises(self, client, monkeypatch):
+        """POST /webhook with malformed payload → error (KeyError on missing key)."""
+        monkeypatch.setattr(
+            "src.routers.webhook.clone_repo_to_temp_folder",
+            lambda url: None,
+        )
+        # Payload is missing "repository" key entirely
+        response = client.post("/webhook", json={"ref": "refs/heads/main"})
+        # Should raise a server error (500) since the router accesses keys directly
+        assert response.status_code == 500


### PR DESCRIPTION
* fix(pydantic-v2-upgrades): Changed all .dict() to .model_dump()
* fix(job-dispatch): Changed how CQL and NLPQL jobs are dispatched to avoid synchronous processing
* fix(datetime-formats): Fixed datetime parsing for NLPQL results to avoid incorrect datetime formats that cause errors
* fix(job-dispatch): Changed how child jobs are dispatched in SmartChart UI router to avoid synchronous processing of background tasks
* fix(try-except-catches): Fixed all instances of try/except where it was trying to catch a KeyError but could also catch an IndexError
* fix(env-var-handling): Add better NLPaaS environment variable string handling
* chore(example-env): Adding an .env.example to the repo
* fix(router-ordering): Reorder NLPQL Router in main.py to avoid overwriting a route
* chore(dep-swapping): Swapping out fastapi-restful for fastapi-utils for more up to date package
* feat(testing): added testing for API using pytest, including faked data as well as real integration tests